### PR TITLE
feat(nuke): cleaning nuke.lib prints, adding active viewer frame ranges

### DIFF
--- a/avalon/nuke/lib.py
+++ b/avalon/nuke/lib.py
@@ -216,21 +216,17 @@ def get_node_path(path, padding=4):
 
     """
     filename, ext = os.path.splitext(path)
-    print(filename)
-    print(filename, ext)
     # Find a final number group
     if '%' in filename:
-        print("I am here")
         match = re.match('.*?(%[0-9]+d)$', filename)
-        print(match)
         if match:
             padding = int(match.group(1).replace('%', '').replace('d', ''))
             # remove number from end since fusion
             # will swap it with the frame number
             filename = filename.replace(match.group(1), '')
+            
     elif '#' in filename:
         match = re.match('.*?(#+)$', filename)
-
         if match:
             padding = len(match.group(1))
             # remove number from end since fusion

--- a/avalon/nuke/pipeline.py
+++ b/avalon/nuke/pipeline.py
@@ -292,9 +292,7 @@ def _install_menu():
     menu.addCommand("Library...", libraryloader.show)
 
     menu.addSeparator()
-    frames_menu = menu.addMenu("Reset Frame Range")
-    frames_menu.addCommand("Cut length", reset_frame_range)
-    frames_menu.addCommand("Full length(handles)", reset_frame_range_handles)
+    menu.addCommand("Reset Frame Range", reset_frame_range_handles)
     menu.addCommand("Reset Resolution", reset_resolution)
 
     menu.addSeparator()
@@ -365,6 +363,15 @@ def reset_frame_range_handles():
 
     nuke.root()["first_frame"].setValue(edit_in)
     nuke.root()["last_frame"].setValue(edit_out)
+
+    # setting active viewers
+    vv = nuke.activeViewer().node()
+    vv['frame_range_lock'].setValue(True)
+    vv['frame_range'].setValue('{0}-{1}'.format(
+        int(asset["data"]["fstart"]),
+        int(asset["data"]["fend"]))
+    )
+
 
 
 def get_handles(asset):


### PR DESCRIPTION
Improving the way Set Frame Range works in Avalon menu.
- it will set frame range for the script
- it will define handles in active viewer frame range slider