### PR TITLE
PYPE-459_workdir_not_created

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -994,7 +994,13 @@ def update_current_task(task=None, asset=None, app=None):
     template = project["config"]["template"]["work"]
     _session = Session.copy()
     _session.update(changed)
-    changed["AVALON_WORKDIR"] = _format_work_template(template, _session)
+    workdir = os.path.normpath(_format_work_template(template, _session))
+
+    changed["AVALON_WORKDIR"] = workdir
+    try:
+        os.makedirs(workdir)
+    except FileExistsError:
+        pass
 
     # Update the full session in one go to avoid half updates
     Session.update(changed)


### PR DESCRIPTION
- workdir is created when update_current_task is called (on accept button in context manager)