### PR TITLE
select_assets expect list or tuple

### DIFF
--- a/avalon/tools/gui/widgets/widget_assets.py
+++ b/avalon/tools/gui/widgets/widget_assets.py
@@ -163,6 +163,8 @@ class AssetsWidget(QtWidgets.QWidget):
         """
         # TODO: Instead of individual selection optimize for many assets
 
+        if not isinstance(assets, (tuple, list)):
+            assets = [assets]
         assert isinstance(
             assets, (tuple, list)
         ), "Assets must be list or tuple"


### PR DESCRIPTION
select_assets expect list or tuple but single item is feeded as str. Therefor switching context doesn't work. String is converted to list and all is ok.