### PR TITLE
naive check of sequences in filename during path_from_data

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1341,6 +1341,9 @@ def get_representation_path(representation):
             return os.path.normpath(path)
 
         dir_path, file_name = os.path.split(path)
+        if not os.path.exists(dir_path):
+            return
+
         base_name, ext = os.path.splitext(file_name)
         file_name_items = None
         if "#" in base_name:

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1340,6 +1340,23 @@ def get_representation_path(representation):
         if os.path.exists(path):
             return os.path.normpath(path)
 
+        dir_path, file_name = os.path.split(path)
+        base_name, ext = os.path.splitext(file_name)
+        file_name_items = None
+        if "#" in base_name:
+            file_name_items = [part for part in base_name.split("#") if part]
+        elif "%" in base_name:
+            file_name_items = base_name.split("%")
+
+        if not file_name_items:
+            return
+
+        filename_start = file_name_items[0]
+
+        for _file in os.listdir(dir_path):
+            if _file.startswith(filename_start) and _file.endswith(ext):
+                return os.path.normpath(path)
+
     return (
         path_from_represenation() or
         path_from_config() or


### PR DESCRIPTION
- added easy check if filename has `#` or `%` then will try to find in files at same directory if any matches same start of filename and extension
- `seq01_sh00030_plateMain_v001.####.exr` will be split by "#" and checked if exist file which start with "seq01_sh00030_plateMain_v001." and ends with ".exr" (similar for `seq01_sh00030_plateMain_v001.%04d.exr`)