### PR TITLE
Feature/pype-725 #close maya frame range

### DIFF
--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -14,24 +14,30 @@ from .. import io, api
 
 def reset_frame_range():
     """Set frame range to current asset"""
-    shot = api.Session["AVALON_ASSET"]
-    shot = io.find_one({"name": shot, "type": "asset"})
+    asset_name = api.Session["AVALON_ASSET"]
+    asset = io.find_one({"name": asset_name, "type": "asset"})
 
-    try:
+    frame_start = asset["data"].get(
+        "frameStart",
+        # backwards compatibility
+        asset["data"].get("edit_in")
+    )
+    frame_end = asset["data"].get(
+        "frameEnd",
+        # backwards compatibility
+        asset["data"].get("edit_out")
+    )
 
-        frame_start = shot["data"].get(
-            "frameStart",
-            # backwards compatibility
-            shot["data"].get("edit_in")
-        )
-        frame_end = shot["data"].get(
-            "frameEnd",
-            # backwards compatibility
-            shot["data"].get("edit_out")
-        )
-    except KeyError:
-        cmds.warning("No edit information found for %s" % shot["name"])
+    if frame_start is None or frame_end is None:
+        cmds.warning("No edit information found for %s" % asset_name)
         return
+
+    handles = int(asset["data"].get("handles", 0))
+    handle_start = int(asset["data"].get("handleStart", handles))
+    handle_end = int(asset["data"].get("handleEnd", handles))
+
+    frame_start -= handle_start
+    frame_end += handle_end
 
     fps = {15: 'game',
            24: 'film',

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -14,6 +14,27 @@ from .. import io, api
 
 def reset_frame_range():
     """Set frame range to current asset"""
+    # Set FPS first
+    fps = {15: 'game',
+           24: 'film',
+           25: 'pal',
+           30: 'ntsc',
+           48: 'show',
+           50: 'palf',
+           60: 'ntscf',
+           23.98: '23.976fps',
+           23.976: '23.976fps',
+           29.97: '29.97fps',
+           47.952: '47.952fps',
+           47.95: '47.952fps',
+           59.94: '59.94fps',
+           44100: '44100fps',
+           48000: '48000fps'
+           }.get(float(api.Session.get("AVALON_FPS", 25)), "pal")
+
+    cmds.currentUnit(time=fps)
+
+    # Set frame start/end
     asset_name = api.Session["AVALON_ASSET"]
     asset = io.find_one({"name": asset_name, "type": "asset"})
 
@@ -38,25 +59,6 @@ def reset_frame_range():
 
     frame_start -= handle_start
     frame_end += handle_end
-
-    fps = {15: 'game',
-           24: 'film',
-           25: 'pal',
-           30: 'ntsc',
-           48: 'show',
-           50: 'palf',
-           60: 'ntscf',
-           23.98: '23.976fps',
-           23.976: '23.976fps',
-           29.97: '29.97fps',
-           47.952: '47.952fps',
-           47.95: '47.952fps',
-           59.94: '59.94fps',
-           44100: '44100fps',
-           48000: '48000fps'
-           }.get(float(api.Session.get("AVALON_FPS", 25)), "pal")
-
-    cmds.currentUnit(time=fps)
 
     cmds.playbackOptions(minTime=frame_start)
     cmds.playbackOptions(maxTime=frame_end)


### PR DESCRIPTION
- `reset_frame_range` updated with handles
- removed try except (it was impossible to raise KeyError there)
- renamed `shot` variables to `asset`
- fps is set first since does not require asset entity