### PR TITLE
Feature/maya reset frame range handles

### DIFF
--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -68,6 +68,9 @@ def reset_frame_range():
     cmds.playbackOptions(maxTime=frame_end)
     cmds.currentTime(frame_start)
 
+    cmds.setAttr("defaultRenderGlobals.startFrame", frame_start)
+    cmds.setAttr("defaultRenderGlobals.endFrame", frame_end)
+
 
 def reset_resolution():
     project = io.find_one({"type": "project"})


### PR DESCRIPTION
This PR is adding ability to set correct frame range in Render Settings when doing *Frame Reset* operations (manually or on context switch)