### PR TITLE
Bugfix/multiroot cleanup

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -335,8 +335,7 @@ class Application(Action):
     config = None
 
     def is_compatible(self, session):
-        required = ["AVALON_PROJECTS",
-                    "AVALON_PROJECT",
+        required = ["AVALON_PROJECT",
                     "AVALON_ASSET",
                     "AVALON_TASK"]
         missing = [x for x in required if x not in session]

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -379,9 +379,8 @@ class Application(Action):
         env = acre.append(dict(os.environ), dyn_env)
 
         # Build environment
-        # env = os.environ.copy()
         env.update(self.config.get("environment", {}))
-        # env.update(dyn_env)
+        env.update(anatomy.root_environments())
         env.update(session)
 
         return env

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -366,7 +366,10 @@ class Application(Action):
             tools_attr.append(session["AVALON_APP_NAME"])
 
         # collect all the 'environment' attributes from parents
-        asset = io.find_one({"type": "asset"})
+        asset = io.find_one({
+            "type": "asset",
+            "name": session["AVALON_ASSET"]
+        })
         tools = self.find_tools(asset)
         tools_attr.extend(tools)
 


### PR DESCRIPTION
Changes:
Root environments are also set when running with avalon application.
Application action does not require `AVALON_PROJECTS` key in session.

Fixed random bug:
Asset is queried by name istead of random asset from project.