### PR TITLE
3.0/feature/pype refactor start

### DIFF
--- a/avalon/lib.py
+++ b/avalon/lib.py
@@ -296,14 +296,24 @@ def find_submodule(module, submodule):
         types.ModuleType or None: The module, if found.
 
     """
-    name = "{0}.{1}".format(module.__name__, submodule)
     try:
+        name = "{0}.hosts.{1}".format(module.__name__, submodule)
         return importlib.import_module(name)
-    except ImportError as exc:
-        if str(exc) != "No module name {}".format(name):
-            log_.warning("Could not find '%s' in module: %s",
-                         submodule,
-                         module)
+    except ImportError:
+        log_.warning(
+            (
+                "Could not find \"{}\". Trying backwards compatible approach."
+            ).format(name),
+            exc_info=True
+        )
+        try:
+            name = "{0}.{1}".format(module.__name__, submodule)
+            return importlib.import_module(name)
+        except ImportError as exc:
+            if str(exc) != "No module name {}".format(name):
+                log_.warning(
+                    "Could not find '%s' in module: %s", submodule, module
+                )
 
 
 class MasterVersionType(object):


### PR DESCRIPTION
This PR requires pype https://github.com/pypeclub/pype/pull/169 and pype-config: https://github.com/pypeclub/pype-config/pull/27.

Issue:
New structure of pype requires to import modules from `hosts` subfolder in avalon's config installation.

Solution:
Avalon config import was modified to be check `{config}.hosts.{host_name}` first