### PR TITLE
feature/205-move tray to pype

### DIFF
--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -250,7 +250,7 @@ QMenu::item
 
 QMenu::item:selected
 {
-    color: black;
+    color: white;
 }
 
 QMenu::separator {


### PR DESCRIPTION
Small style tweak to have visible menu items in tray.
- QMenu item has white text on hover to have readable text due to changes in hover background changes in avalon-core