### PR TITLE
Feature/modify cloud mongo

### DIFF
--- a/avalon/io.py
+++ b/avalon/io.py
@@ -183,12 +183,6 @@ def _from_environment():
             # Address to Asset Database
             ("AVALON_MONGO", "mongodb://localhost:27017"),
 
-            # Address to Asset Database without port
-            ("AVALON_MONGO_HOST", "mongodb://localhost"),
-
-            # Address to Asset Database port
-            ("AVALON_MONGO_PORT", "27017"),
-
             # Name of database used in MongoDB
             ("AVALON_DB", "avalon"),
 

--- a/avalon/io.py
+++ b/avalon/io.py
@@ -44,6 +44,19 @@ self._database = None
 self._is_installed = False
 
 log = logging.getLogger(__name__)
+PY2 = sys.version_info[0] == 2
+
+
+def extract_port_from_url(url):
+    if PY2:
+        from urlparse import urlparse
+    else:
+        from urllib.parse import urlparse
+    parsed_url = urlparse(url)
+    if parsed_url.scheme is None:
+        _url = "mongodb://{}".format(url)
+        parsed_url = urlparse(_url)
+    return parsed_url.port
 
 
 def install():
@@ -55,11 +68,17 @@ def install():
     Session.update(_from_environment())
 
     timeout = int(Session["AVALON_TIMEOUT"])
-    self._mongo_client = pymongo.MongoClient(
-        host=Session["AVALON_MONGO_HOST"],
-        port=int(Session["AVALON_MONGO_PORT"]),
-        serverSelectionTimeoutMS=timeout
-    )
+    mongo_url = Session["AVALON_MONGO"]
+    kwargs = {
+        "host": mongo_url,
+        "serverSelectionTimeoutMS": timeout
+    }
+
+    port = extract_port_from_url(mongo_url)
+    if port is not None:
+        kwargs["port"] = int(port)
+
+    self._mongo_client = pymongo.MongoClient(**kwargs)
 
     for retry in range(3):
         try:

--- a/avalon/tools/libraryloader/io_nonsingleton.py
+++ b/avalon/tools/libraryloader/io_nonsingleton.py
@@ -16,6 +16,7 @@ import contextlib
 
 from ... import schema
 from ...vendor import requests
+from avalon.io import extract_port_from_url
 
 # Third-party dependencies
 import pymongo
@@ -59,11 +60,17 @@ class DbConnector(object):
         self.Session.update(self._from_environment())
 
         timeout = int(self.Session["AVALON_TIMEOUT"])
-        self._mongo_client = pymongo.MongoClient(
-            host=self.Session["AVALON_MONGO_HOST"],
-            port=int(self.Session["AVALON_MONGO_PORT"]),
-            serverSelectionTimeoutMS=timeout
-        )
+        mongo_url = self.Session["AVALON_MONGO"]
+        kwargs = {
+            "host": mongo_url,
+            "serverSelectionTimeoutMS": timeout
+        }
+
+        port = extract_port_from_url(mongo_url)
+        if port is not None:
+            kwargs["port"] = int(port)
+
+        self._mongo_client = pymongo.MongoClient(**kwargs)
 
         for retry in range(3):
             try:

--- a/avalon/tools/libraryloader/io_nonsingleton.py
+++ b/avalon/tools/libraryloader/io_nonsingleton.py
@@ -164,12 +164,6 @@ class DbConnector(object):
                 # Address to Asset Database
                 ("AVALON_MONGO", "mongodb://localhost:27017"),
 
-                # Address to Asset Database without port
-                ("AVALON_MONGO_HOST", "mongodb://localhost"),
-
-                # Address to Asset Database port
-                ("AVALON_MONGO_PORT", "27017"),
-
                 # Name of database used in MongoDB
                 ("AVALON_DB", "avalon"),
 


### PR DESCRIPTION
## Changes
- Get rid of environments `AVALON_MONGO_HOST` and `AVALON_MONGO_PORT`. Kept only `AVALON_MONGO` and function to extract port from url.

### Requires
- pype-setup
- pype
- pype-config
- avalon-core