### PR TITLE
Feature/workfiles api extraction

### DIFF
--- a/avalon/api.py
+++ b/avalon/api.py
@@ -56,6 +56,8 @@ from .pipeline import (
 
     deregister_plugin,
     deregister_plugin_path,
+
+    HOST_WORKFILE_EXTENSIONS,
 )
 
 from .lib import (
@@ -109,6 +111,8 @@ __all__ = [
 
     "deregister_plugin",
     "deregister_plugin_path",
+
+    "HOST_WORKFILE_EXTENSIONS",
 
     "logger",
     "time",

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -58,6 +58,8 @@ from .pipeline import (
     deregister_plugin_path,
 
     HOST_WORKFILE_EXTENSIONS,
+    format_template_with_optional_keys,
+    last_workfile_version
 )
 
 from .lib import (
@@ -113,6 +115,8 @@ __all__ = [
     "deregister_plugin_path",
 
     "HOST_WORKFILE_EXTENSIONS",
+    "format_template_with_optional_keys",
+    "last_workfile_version",
 
     "logger",
     "time",

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -59,7 +59,7 @@ from .pipeline import (
 
     HOST_WORKFILE_EXTENSIONS,
     format_template_with_optional_keys,
-    last_workfile_version,
+    last_workfile_with_version,
     last_workfile
 )
 
@@ -117,7 +117,7 @@ __all__ = [
 
     "HOST_WORKFILE_EXTENSIONS",
     "format_template_with_optional_keys",
-    "last_workfile_version",
+    "last_workfile_with_version",
     "last_workfile",
 
     "logger",

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -59,7 +59,8 @@ from .pipeline import (
 
     HOST_WORKFILE_EXTENSIONS,
     format_template_with_optional_keys,
-    last_workfile_version
+    last_workfile_version,
+    last_workfile
 )
 
 from .lib import (
@@ -117,6 +118,7 @@ __all__ = [
     "HOST_WORKFILE_EXTENSIONS",
     "format_template_with_optional_keys",
     "last_workfile_version",
+    "last_workfile",
 
     "logger",
     "time",

--- a/avalon/blender/workio.py
+++ b/avalon/blender/workio.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import bpy
+from avalon import api
 
 
 def open_file(filepath: str) -> Optional[str]:
@@ -59,7 +60,7 @@ def has_unsaved_changes() -> bool:
 def file_extensions() -> List[str]:
     """Return the supported file extensions for Blender scene files."""
 
-    return [".blend"]
+    return api.HOST_WORKFILE_EXTENSIONS["blender"]
 
 
 def work_root(session: dict) -> str:

--- a/avalon/fusion/workio.py
+++ b/avalon/fusion/workio.py
@@ -1,10 +1,11 @@
 """Host API required Work Files tool"""
 import sys
 import os
+from avalon import api
 
 
 def file_extensions():
-    return [".comp"]
+    return api.HOST_WORKFILE_EXTENSIONS["fusion"]
 
 
 def has_unsaved_changes():

--- a/avalon/harmony/workio.py
+++ b/avalon/harmony/workio.py
@@ -3,10 +3,11 @@ import os
 import shutil
 
 from . import lib
+from avalon import api
 
 
 def file_extensions():
-    return [".zip"]
+    return api.HOST_WORKFILE_EXTENSIONS["harmony"]
 
 
 def has_unsaved_changes():

--- a/avalon/houdini/workio.py
+++ b/avalon/houdini/workio.py
@@ -2,10 +2,11 @@
 import os
 
 import hou
+from avalon import api
 
 
 def file_extensions():
-    return [".hip", ".hiplc", ".hipnc"]
+    return api.HOST_WORKFILE_EXTENSIONS["houdini"]
 
 
 def has_unsaved_changes():

--- a/avalon/maya/workio.py
+++ b/avalon/maya/workio.py
@@ -14,12 +14,7 @@ def has_unsaved_changes():
 
 def save_file(filepath):
     cmds.file(rename=filepath)
-    ext = os.path.splitext(filepath)[1]
-    if ext == ".ma":
-        file_type = "mayaAscii"
-    elif ext == ".mb":
-        file_type = "mayaBinary"
-    cmds.file(save=True, type=file_type)
+    cmds.file(save=True, type="mayaAscii")
 
 
 def open_file(filepath):

--- a/avalon/maya/workio.py
+++ b/avalon/maya/workio.py
@@ -1,11 +1,11 @@
 """Host API required Work Files tool"""
 import os
-
 from maya import cmds
+from avalon import api
 
 
 def file_extensions():
-    return [".ma", ".mb"]
+    return api.HOST_WORKFILE_EXTENSIONS["maya"]
 
 
 def has_unsaved_changes():
@@ -14,7 +14,12 @@ def has_unsaved_changes():
 
 def save_file(filepath):
     cmds.file(rename=filepath)
-    cmds.file(save=True, type="mayaAscii")
+    ext = os.path.splitext(filepath)[1]
+    if ext == ".ma":
+        file_type = "mayaAscii"
+    elif ext == ".mb":
+        file_type = "mayaBinary"
+    cmds.file(save=True, type=file_type)
 
 
 def open_file(filepath):

--- a/avalon/nuke/workio.py
+++ b/avalon/nuke/workio.py
@@ -5,7 +5,7 @@ from avalon import api
 
 
 def file_extensions():
-    return [".nk"]
+    return api.HOST_WORKFILE_EXTENSIONS["nuke"]
 
 
 def has_unsaved_changes():

--- a/avalon/photoshop/workio.py
+++ b/avalon/photoshop/workio.py
@@ -2,6 +2,7 @@
 import os
 
 from . import lib
+from avalon import api
 
 
 def _active_document():
@@ -12,7 +13,7 @@ def _active_document():
 
 
 def file_extensions():
-    return [".psd"]
+    return api.HOST_WORKFILE_EXTENSIONS["photoshop"]
 
 
 def has_unsaved_changes():

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1686,7 +1686,9 @@ def last_workfile_version(workdir, file_template, fill_data, extensions):
     return version
 
 
-def last_workfile(workdir, file_template, fill_data, extensions):
+def last_workfile(
+    workdir, file_template, fill_data, extensions, full_path=False
+):
     """Return last workfile name.
 
     Returns file with version 1 if there is not workfile yet.
@@ -1699,4 +1701,7 @@ def last_workfile(workdir, file_template, fill_data, extensions):
     data = copy.deepcopy(fill_data)
     data["version"] = version
 
-    return format_template_with_optional_keys(data, file_template)
+    output = format_template_with_optional_keys(data, file_template)
+    if full_path:
+        output = os.path.join(workdir, output)
+    return output

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1632,11 +1632,11 @@ def last_workfile_version(workdir, file_template, fill_data, extensions):
         extensions(list, tuple): All allowed file extensions of workfile.
 
     Returns:
-        int: Last workfile version if there is any.
-        None: If workdir does not exist or there is not existing workfile yet.
+        tuple: Last workfile<str> with version<int> if there is any otherwise
+            returns (None, None).
     """
     if not os.path.exists(workdir):
-        return None
+        return None, None
 
     # Fast match on extension
     filenames = [
@@ -1676,6 +1676,7 @@ def last_workfile_version(workdir, file_template, fill_data, extensions):
         kwargs["flags"] = re.IGNORECASE
 
     # Get highest version among existing matching files
+    output_filename = None
     version = None
     for filename in sorted(filenames):
         match = re.match(file_template, filename, **kwargs)
@@ -1683,7 +1684,8 @@ def last_workfile_version(workdir, file_template, fill_data, extensions):
             file_version = int(match.group(1))
             if version is None or file_version >= version:
                 version = file_version
-    return version
+                output_filename = filename
+    return output_filename, version
 
 
 def last_workfile(

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1691,19 +1691,31 @@ def last_workfile_with_version(workdir, file_template, fill_data, extensions):
 def last_workfile(
     workdir, file_template, fill_data, extensions, full_path=False
 ):
-    """Return last workfile name.
+    """Return last workfile filename.
 
     Returns file with version 1 if there is not workfile yet.
+
+    Args:
+        workdir(str): Path to dir where workfiles are stored.
+        file_template(str): Template of file name.
+        fill_data(dict): Data for filling template.
+        extensions(list, tuple): All allowed file extensions of workfile.
+        full_path(bool): Full path to file is returned if set to True.
+
+    Returns:
+        str: Last or first workfile as filename of full path to filename.
     """
-    version = last_workfile_version(
+    filename, version = last_workfile_with_version(
         workdir, file_template, fill_data, extensions
     )
-    if version is None:
-        version = 1
-    data = copy.deepcopy(fill_data)
-    data["version"] = version
+    if filename is None:
+        data = copy.deepcopy(fill_data)
+        data["version"] = 1
+        data.pop("comment", None)
+        if not data.get("ext"):
+            data["ext"] = extensions[0]
+        filename = format_template_with_optional_keys(data, file_template)
 
-    output = format_template_with_optional_keys(data, file_template)
     if full_path:
-        output = os.path.join(workdir, output)
-    return output
+        return os.path.join(workdir, filename)
+    return filename

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -45,6 +45,18 @@ log = logging.getLogger(__name__)
 
 AVALON_CONTAINER_ID = "pyblish.avalon.container"
 
+HOST_WORKFILE_EXTENSIONS = {
+    "blender": [".blend"],
+    "fusion": [".comp"],
+    "harmony": [".zip"],
+    "houdini": [".hip", ".hiplc", ".hipnc"],
+    "maya": [".ma", ".mb"],
+    "nuke": [".nk"],
+    "nukestudio": [".hrox"],
+    "photoshop": [".psd"],
+    "premiere": [".prproj"]
+}
+
 
 class IncompatibleLoaderError(ValueError):
     """Error when Loader is incompatible with a representation."""

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -54,7 +54,8 @@ HOST_WORKFILE_EXTENSIONS = {
     "nuke": [".nk"],
     "nukestudio": [".hrox"],
     "photoshop": [".psd"],
-    "premiere": [".prproj"]
+    "premiere": [".prproj"],
+    "resolve": [".drp"]
 }
 
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1622,7 +1622,7 @@ def loaders_from_representation(loaders, representation):
     return [l for l in loaders if is_compatible_loader(l, context)]
 
 
-def last_workfile_version(workdir, file_template, fill_data, extensions):
+def last_workfile_with_version(workdir, file_template, fill_data, extensions):
     """Return last workfile version.
 
     Args:

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -392,7 +392,6 @@ class Application(Action):
             )
 
         if last_workfile_path:
-            print(last_workfile_path)
             session["AVALON_LAST_WORKFILE"] = last_workfile_path
 
         # dynamic environmnets

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -371,6 +371,29 @@ class Application(Action):
         anatomy_filled = anatomy.format(template_data)
         session["AVALON_WORKDIR"] = anatomy_filled["work"]["folder"]
 
+        last_workfile_path = None
+        extensions = HOST_WORKFILE_EXTENSIONS.get(session["AVALON_APP"])
+        if extensions:
+            # Find last workfile
+            file_template = anatomy.templates["work"]["file"]
+            template_data.update({
+                "version": 1,
+                "user": getpass.getuser(),
+                "ext": extensions[0]
+            })
+
+            last_workfile_path = last_workfile(
+                session["AVALON_WORKDIR"],
+                file_template,
+                template_data,
+                extensions,
+                True
+            )
+
+        if last_workfile_path:
+            print(last_workfile_path)
+            session["AVALON_LAST_WORKFILE"] = last_workfile_path
+
         # dynamic environmnets
         tools_attr = []
         if session["AVALON_APP"] is not None:

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1684,3 +1684,19 @@ def last_workfile_version(workdir, file_template, fill_data, extensions):
             if version is None or file_version >= version:
                 version = file_version
     return version
+
+
+def last_workfile(workdir, file_template, fill_data, extensions):
+    """Return last workfile name.
+
+    Returns file with version 1 if there is not workfile yet.
+    """
+    version = last_workfile_version(
+        workdir, file_template, fill_data, extensions
+    )
+    if version is None:
+        version = 1
+    data = copy.deepcopy(fill_data)
+    data["version"] = version
+
+    return format_template_with_optional_keys(data, file_template)

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -184,9 +184,9 @@ class NameWindow(QtWidgets.QDialog):
             if not data["comment"]:
                 data.pop("comment", None)
 
-            version = api.last_workfile_version(
+            version = api.last_workfile_with_version(
                 self.root, template, data, extensions
-            )
+            )[1]
 
             if version is None:
                 version = 1


### PR DESCRIPTION
## Changes
- Hosts extensions are not defined in host implementation but in `avalon.pipeline.HOST_WORKFILE_EXTENSIONS` to be easily accessible without outside host
- implemented `last_workfile_version` which returns last workfile version as integer or None if there is none
- implemented `last_workfile` which returns filename or full path of latest workfile
    - returns filename for version 1 if there is none yet
- workfiles tool use those functions
- there is set environment variable `AVALON_LAST_WORKFILE` where path to last workfile is stored or first version

### Requires
- pype
- avalon-core