### PR TITLE
feature/maya support mb workfile

### DIFF
--- a/avalon/maya/workio.py
+++ b/avalon/maya/workio.py
@@ -14,7 +14,12 @@ def has_unsaved_changes():
 
 def save_file(filepath):
     cmds.file(rename=filepath)
-    cmds.file(save=True, type="mayaAscii")
+    ext = os.path.splitext(filepath)[1]
+    if ext == ".mb":
+        file_type = "mayaBinary"
+    else:
+        file_type = "mayaAscii"
+    cmds.file(save=True, type=file_type)
 
 
 def open_file(filepath):


### PR DESCRIPTION
## Issue
It is not possible to save workfile as `.mb`.

## Suggested solution
Check for extension in `maya.workio.save_file` to define file type.