### PR TITLE
Scene Metadata

### DIFF
--- a/avalon/harmony/__init__.py
+++ b/avalon/harmony/__init__.py
@@ -20,7 +20,8 @@ from .lib import (
     maintained_nodes_state,
     save_scene,
     save_scene_as,
-    remove
+    remove,
+    find_node_by_name
 )
 
 from .workio import (
@@ -49,6 +50,7 @@ __all__ = [
     "save_scene",
     "save_scene_as",
     "remove",
+    "find_node_by_name",
 
     # Workfiles API
     "open_file",

--- a/avalon/harmony/__init__.py
+++ b/avalon/harmony/__init__.py
@@ -19,7 +19,8 @@ from .lib import (
     send,
     maintained_nodes_state,
     save_scene,
-    save_scene_as
+    save_scene_as,
+    remove
 )
 
 from .workio import (
@@ -47,6 +48,7 @@ __all__ = [
     "maintained_nodes_state",
     "save_scene",
     "save_scene_as",
+    "remove",
 
     # Workfiles API
     "open_file",

--- a/avalon/harmony/pipeline.py
+++ b/avalon/harmony/pipeline.py
@@ -135,7 +135,7 @@ def containerise(name,
                  node,
                  context,
                  loader=None,
-                 suffix="_CON"):
+                 suffix=None):
     """Imprint node with metadata.
 
     Containerisation enables a tracking of version, author and origin

--- a/avalon/harmony/pipeline.py
+++ b/avalon/harmony/pipeline.py
@@ -24,23 +24,15 @@ def ls():
     Yields:
         dict: container
     """
-    read_nodes = lib.send(
-        {"function": "node.getNodes", "args": [["READ"]]}
-    )["result"]
-
-    for node in read_nodes:
-        data = lib.read(node)
-
-        # Skip non-tagged layers.
+    objects = lib.get_scene_data()
+    for id, data in objects.items():
+        # Skip non-tagged objects.
         if not data:
             continue
 
         # Filter to only containers.
         if "container" not in data["id"]:
             continue
-
-        # Append transient data
-        data["node"] = node
 
         yield data
 
@@ -160,15 +152,13 @@ def containerise(name,
     Returns:
         container (str): Path of container assembly.
     """
-    lib.send({"function": "node.rename", "args": [node, name + suffix]})
-
     data = {
         "schema": "avalon-core:container-2.0",
         "id": pipeline.AVALON_CONTAINER_ID,
         "name": name,
         "namespace": namespace,
         "loader": str(loader),
-        "representation": str(context["representation"]["_id"]),
+        "representation": str(context["representation"]["_id"])
     }
 
     lib.imprint(node, data)

--- a/avalon/harmony/pipeline.py
+++ b/avalon/harmony/pipeline.py
@@ -25,7 +25,7 @@ def ls():
         dict: container
     """
     objects = lib.get_scene_data()
-    for id, data in objects.items():
+    for _, data in objects.items():
         # Skip non-tagged objects.
         if not data:
             continue


### PR DESCRIPTION
Metadata for each container is stored on the scene level, instead of on nodes only.

This enables the Harmony implementation to containerize other objects than nodes.

This does break backwards compatibility, but the production data using this is minimal.