### PR TITLE
Harmony: fix race condition in server

### DIFF
--- a/avalon/harmony/server.py
+++ b/avalon/harmony/server.py
@@ -112,9 +112,11 @@ class Server(object):
                 self._send(json.dumps(request))
                 self.log.debug("Processing request ...")
                 self.process_request(request)
-                self.log.debug("Removing from queue {}".format(request["mId"]))
+
                 if "mId" in request.keys():
                     try:
+                        self.log.debug("Removing from queue {}".format(
+                            request["mId"]))
                         del self.queue[request["mId"]]
                     except IndexError:
                         self.log.debug("{} is no longer in queue".format(


### PR DESCRIPTION
## Problem

sometimes when using `send()` function on Python side result was returned faster then `send()` could block and wait. This resulted in unprocessed replies from Harmony.

## Fix

This fix is storing every recieved request in queue. `send()` is then looking there for it. It is removed after being processed.