### PR TITLE
Bugfix/185 maya reset frame range missing attributes are not handled correctly

### DIFF
--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -54,8 +54,13 @@ def reset_frame_range():
         return
 
     handles = asset["data"].get("handles") or 0
-    handle_start = int(asset["data"].get("handleStart", handles))
-    handle_end = int(asset["data"].get("handleEnd", handles))
+    handle_start = asset["data"].get("handleStart")
+    if handle_start is None:
+        handle_start = handles
+
+    handle_end = asset["data"].get("handleEnd")
+    if handle_end is None:
+        handle_end = handles
 
     frame_start -= handle_start
     frame_end += handle_end

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -53,7 +53,7 @@ def reset_frame_range():
         cmds.warning("No edit information found for %s" % asset_name)
         return
 
-    handles = int(asset["data"].get("handles", 0))
+    handles = asset["data"].get("handles") or 0
     handle_start = int(asset["data"].get("handleStart", handles))
     handle_end = int(asset["data"].get("handleEnd", handles))
 

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -38,16 +38,12 @@ def reset_frame_range():
     asset_name = api.Session["AVALON_ASSET"]
     asset = io.find_one({"name": asset_name, "type": "asset"})
 
-    frame_start = asset["data"].get(
-        "frameStart",
-        # backwards compatibility
-        asset["data"].get("edit_in")
-    )
-    frame_end = asset["data"].get(
-        "frameEnd",
-        # backwards compatibility
-        asset["data"].get("edit_out")
-    )
+    frame_start = asset["data"].get("frameStart")
+    frame_end = asset["data"].get("frameEnd")
+    # Backwards compatibility
+    if frame_start is None or frame_end is None:
+        frame_start = asset["data"].get("edit_in")
+        frame_end = asset["data"].get("edit_out")
 
     if frame_start is None or frame_end is None:
         cmds.warning("No edit information found for %s" % asset_name)

--- a/avalon/maya/commands.py
+++ b/avalon/maya/commands.py
@@ -62,8 +62,8 @@ def reset_frame_range():
     if handle_end is None:
         handle_end = handles
 
-    frame_start -= handle_start
-    frame_end += handle_end
+    frame_start -= int(handle_start)
+    frame_end += int(handle_end)
 
     cmds.playbackOptions(minTime=frame_start)
     cmds.playbackOptions(maxTime=frame_end)


### PR DESCRIPTION
## Issue
- Reset frame range does not handle `None` values of keys we work with

## Changes
- values of keys `handles`, `handleStart` and `handleEnd` are more secure to not set values
    - `handles` are set to `0` if key is not set or it's value is `None`
    - `handleStart` and `handleEnd` are overriden with `handles` only if are not set at all or their values are set to `None`
    - integer conversion is last part of handles usage

## Question
- Should we also set default values for `frameStart` and `frameEnd`?
