### PR TITLE
Hotfix/auto reconnect reraise

### DIFF
--- a/avalon/io.py
+++ b/avalon/io.py
@@ -255,17 +255,19 @@ def requires_install(f):
 
 def auto_reconnect(f):
     """Handling auto reconnect in 3 retry times"""
+    retry_times = 3
+
     @functools.wraps(f)
     def decorated(*args, **kwargs):
-        for retry in range(3):
+        for retry in range(1, retry_times + 1):
             try:
                 return f(*args, **kwargs)
             except pymongo.errors.AutoReconnect:
                 log.error("Reconnecting..")
-                time.sleep(0.1)
-        else:
-            raise
-
+                if retry < retry_times:
+                    time.sleep(0.1)
+                else:
+                    raise
     return decorated
 
 


### PR DESCRIPTION
## Issue
- decorator `auto_reconnect` in `avalon.io` is reraising exception outside of except block so is not reraised but another exception is raised `RuntimeError: No active exception to reraise`

## Changes
- modified reconnect to be able raise exception inside except block