### PR TITLE
Feature/open harmony

### DIFF
--- a/avalon/harmony/OpenHarmony.js
+++ b/avalon/harmony/OpenHarmony.js
@@ -1,0 +1,2 @@
+var LIB_OPENHARMONY_PATH = System.getenv('LIB_OPENHARMONY_PATH');
+include(LIB_OPENHARMONY_PATH +'\\openHarmony.js');

--- a/avalon/harmony/lib.py
+++ b/avalon/harmony/lib.py
@@ -16,7 +16,7 @@ import time
 from .server import Server
 from ..vendor.Qt import QtWidgets
 from ..tools import workfiles
-from ..toonboom import setup_startup_scripts
+from ..toonboom import setup_startup_scripts, setup_libs
 
 self = sys.modules[__name__]
 self.server = None
@@ -56,6 +56,7 @@ def launch(application_path):
 
     # Launch Harmony.
     setup_startup_scripts()
+    setup_libs()
 
     if os.environ.get("AVALON_HARMONY_WORKFILES_ON_LAUNCH", False):
         workfiles.show(save=False)

--- a/avalon/harmony/pipeline.py
+++ b/avalon/harmony/pipeline.py
@@ -161,7 +161,7 @@ def containerise(name,
         "loader": str(loader),
         "representation": str(context["representation"]["_id"]),
         "nodes": nodes
-        }
+    }
 
     lib.imprint(node, data)
 

--- a/avalon/toonboom/__init__.py
+++ b/avalon/toonboom/__init__.py
@@ -10,7 +10,8 @@ from .lib import (
     send,
     show,
     save_scene,
-    setup_startup_scripts
+    setup_startup_scripts,
+    setup_libs
 )
 
 __all__ = [
@@ -26,5 +27,6 @@ __all__ = [
     "send",
     "show",
     "save_scene",
-    "setup_startup_scripts"
+    "setup_startup_scripts",
+    "setup_libs"
 ]

--- a/avalon/toonboom/lib.py
+++ b/avalon/toonboom/lib.py
@@ -1,15 +1,15 @@
-import os
-import random
-import sys
-import queue
-import shutil
-import zipfile
-import signal
-import threading
-import subprocess
+import filecmp
 import importlib
 import logging
-import filecmp
+import os
+import queue
+import random
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import zipfile
 
 from .server import Server
 from ..tools import workfiles
@@ -78,6 +78,64 @@ def setup_startup_scripts():
                 os.environ["TOONBOOM_GLOBAL_SCRIPT_LOCATION"] = avalon_dcc_dir
     else:
         os.environ["TOONBOOM_GLOBAL_SCRIPT_LOCATION"] = avalon_dcc_dir
+
+
+def setup_libs():
+    """Manages installation of QtScript libraries like OpenHarmony
+
+    If a studio already has defined "LIB_OPENHARMONY_PATH", this method will
+    gracefully continue without changing the environment or altering any files.
+    This assumes that OpenHarmony has been already installed by the pipeline
+    administrators, and will be available to include with the following:
+    >> include("OpenHarmony.js");
+
+    Otherwise, this env var will be setup to use the version of
+    OpenHarmony that is specified in the deploy.json of pype-setup.
+    As well, "avalon/harmony/OpenHarmony.js" will be copied to the
+    "TOONBOOM_GLOBAL_SCRIPT_LOCATION" directory. OpenHarmony will be available
+    to include with the following:
+    >> include("OpenHarmony.js");
+
+    Note:
+    This method must be run after setup_startup_scripts() as the env var
+    "TOONBOOM_GLOBAL_SCRIPT_LOCATION" must be properly defined.
+
+    """
+    if not os.getenv("LIB_OPENHARMONY_PATH"):
+
+        openharmony_path = os.path.join(
+            os.getenv("PYPE_SETUP"), "repos/OpenHarmony"
+        )
+
+        os.environ["LIB_OPENHARMONY_PATH"] = openharmony_path
+
+        avalon_dcc_dir = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "harmony"
+        )
+
+        avalon_openharmony_include = os.path.join(avalon_dcc_dir,
+                                                  "OpenHarmony.js")
+
+        env_openharmony_include = os.path.join(
+            os.getenv("TOONBOOM_GLOBAL_SCRIPT_LOCATION"), "OpenHarmony.js")
+
+        if os.path.exists(env_openharmony_include):
+            if filecmp.cmp(avalon_openharmony_include,
+                           env_openharmony_include):
+                return
+
+        try:
+            shutil.copy(avalon_openharmony_include,
+                        env_openharmony_include)
+        except Exception as e:
+            self.log.error(e)
+            self.log.warning(
+                "Failed to copy {0} to {1}! "
+                "OpenHarmony is a required library. "
+                "Make sure you have permission to write to the Harmony"
+                " scripts folder!"
+                    .format(avalon_openharmony_include,
+                            env_openharmony_include))
 
 
 def launch(application_path, zip_file):


### PR DESCRIPTION
Added logic for OpenHarmony lib to be available to include in the Harmony host.  

 "OpenHarmony - The Toonboom Harmony Open Source DOM Library" is an excellent library that simplifies complex scripting with object oriented syntax as a wrapper around Harmony's scripting api. 

See the following links: 
https://github.com/cfourney/OpenHarmony
https://cfourney.github.io/OpenHarmony/$.html

This pull request along with the [pull request in pype-setup](https://github.com/pypeclub/pype-setup/pull/61) that adds OpenHarmony 0.3.0 to the repos folder, allows for OpenHarmony to be included with the syntax: `include("OpenHarmony.js");`
inside pype and avalon-core Harmony Qt Script.

Considering that studios may already be using OpenHarmony, the code in this pull request gracefully skips any setup of OpenHarmony in favour of the studio's existing `LIB_OPENHARMONY_PATH`. 

Otherwise, the logic will set this env var for the host session at launch as well as copy over the include proxy file `"avalon-core/avalon/harmony/OpenHarmony.js"` into the `TOONBOOM_GLOBAL_SCRIPT_PATH` location.

