### PR TITLE
Loader actions fix.

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -190,7 +190,8 @@ class Loader(list):
         representation = context['representation']
         project_doc = context.get("project")
         root = None
-        if project_doc and project_doc["name"] != Session["AVALON_PROJECT"]:
+        session_project = Session.get("AVALON_PROJECT")
+        if project_doc and project_doc["name"] != session_project:
             anatomy = Anatomy(project_doc["name"])
             root = anatomy.roots_obj
 


### PR DESCRIPTION
Fix for error when running actions;
```
Traceback (most recent call last):
  File "C:\Users\admin\bumpybox_development\pype-setup\repos\avalon-core\avalon\tools\libraryloader\widgets.py", line 334, in on_context_menu
    representation=representation
  File "C:\Users\admin\bumpybox_development\pype-setup\repos\avalon-core\avalon\tools\libraryloader\lib.py", line 294, in load
    loader = Loader(context)
  File "C:\Users\admin\bumpybox_development\pype-setup\repos\avalon-core\avalon\pipeline.py", line 193, in __init__
    if project_doc and project_doc["name"] != Session["AVALON_PROJECT"]:
KeyError: 'AVALON_PROJECT'
```