### PR TITLE
Bugfix/pyside pyqt file dialog comp

### DIFF
--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -5,6 +5,7 @@ import getpass
 import shutil
 import logging
 
+from ...vendor import Qt
 from ...vendor.Qt import QtWidgets, QtCore
 from ... import style, io, api, pipeline
 
@@ -563,10 +564,12 @@ class FilesWidget(QtWidgets.QWidget):
         filter = "Work File (*{0})".format(filter)
         kwargs = {
             "caption": "Work Files",
-            "directory": self.root,
-            "dir": self.root,
             "filter": filter
         }
+        if Qt.__binding__ in ("PySide", "PySide2"):
+            kwargs["dir"] = self.root
+        else:
+            kwargs["directory"] = self.root
         work_file = QtWidgets.QFileDialog.getOpenFileName(**kwargs)[0]
 
         if not work_file:


### PR DESCRIPTION
## Issue
- method `QFileDialog.getOpenFileName` has different kwargs for PySide/PySide2 than PyQt4/PyQt5, now are passed both kwargs which may cause issues with newer PyQt

## Solution
- only valid kwargs per Qt binding is passed

## NOTE
- Must be tested in Nuke which has strange bindings

