### PR TITLE
Harmony: handle invalid characters in zips

### DIFF
--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -5,6 +5,7 @@ import getpass
 import shutil
 import logging
 
+from ...vendor import Qt
 from ...vendor.Qt import QtWidgets, QtCore
 from ... import style, io, api, pipeline
 
@@ -563,10 +564,12 @@ class FilesWidget(QtWidgets.QWidget):
         filter = "Work File (*{0})".format(filter)
         kwargs = {
             "caption": "Work Files",
-            "directory": self.root,
-            "dir": self.root,
             "filter": filter
         }
+        if Qt.__binding__ in ("PySide", "PySide2"):
+            kwargs["dir"] = self.root
+        else:
+            kwargs["directory"] = self.root
         work_file = QtWidgets.QFileDialog.getOpenFileName(**kwargs)[0]
 
         if not work_file:


### PR DESCRIPTION
## Bug

Sometimes zip coming from Mac can contain files with invalid characters for Windows platform. We found case with `Icon\r` file but potentially there can be many more. Python's **zipfile** module already has basic checks against `:<>|"?*` but is missing `\r`.

## Solution

Extend **zipfile** mechanism with other characters, This is done by subclassing `zipfile.ZipFile` and overriding `_windows_illegal_name_trans_table` defined there that is used to translate illegal characters to `_`.

## Bonus

Added archive verification after zip is created and before it is moved to final destination.