### PR TITLE
Harmony: Increase timeout to 30 minutes

### DIFF
--- a/avalon/harmony/server.py
+++ b/avalon/harmony/server.py
@@ -207,7 +207,7 @@ class Server(object):
                                                       timestamp, try_index))
                 try_index += 1
                 current_time = time.time()
-            if try_index > 4:
+            if try_index > 30:
                 break
             try:
                 result = self.queue[request["message_id"]]


### PR DESCRIPTION
## Change

Sometimes operations in Harmony can take too long and 2 minutes were not enough for heavy scenes. This increases timeout to 15 minutes.

