### PR TITLE
Hotfix/mongo install uninstall fix

### DIFF
--- a/avalon/io.py
+++ b/avalon/io.py
@@ -92,9 +92,7 @@ def _install_sentry():
 
 
 def _from_environment():
-    session = session_data_from_environment(
-        global_keys=True, context_keys=True
-    )
+    session = session_data_from_environment(context_keys=True)
 
     session["schema"] = "avalon-core:session-2.0"
     try:

--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -105,6 +105,9 @@ def session_data_from_environment(context_keys=False):
         for key in SESSION_CONTEXT_KEYS:
             value = os.environ.get(key)
             session_data[key] = value or ""
+    else:
+        for key in SESSION_CONTEXT_KEYS:
+            session_data[key] = None
 
     for key, default_value in (
         # Name of current Config

--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -361,11 +361,6 @@ class AvalonMongoDB:
 
     def uninstall(self):
         """Close any connection to the database"""
-        try:
-            self._mongo_client.close()
-        except AttributeError:
-            pass
-
         AvalonMongoConnection.uninstall(self)
         self._database = None
 

--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -99,15 +99,12 @@ SESSION_CONTEXT_KEYS = (
 )
 
 
-def session_data_from_environment(global_keys=True, context_keys=False):
+def session_data_from_environment(context_keys=False):
     session_data = {}
     if context_keys:
         for key in SESSION_CONTEXT_KEYS:
             value = os.environ.get(key)
             session_data[key] = value or ""
-
-    if not global_keys:
-        return session_data
 
     for key, default_value in (
         # Name of current Config


### PR DESCRIPTION
## Changes
- Session global keys are always filled
- Session context keys are filled with None if should not use values from environments
- `AvalonmongoDB` had invalid `uninstall` method which used not existing variable on the object