### PR TITLE
Harmony: make xstage files independent on zip name

### DIFF
--- a/avalon/harmony/lib.py
+++ b/avalon/harmony/lib.py
@@ -127,6 +127,41 @@ def launch_zip_file(filepath):
     # Save workfile path for later.
     self.workfile_path = filepath
 
+    # find any xstage files is directory, prefer the one with the same name
+    # as directory (plus extension)
+    xstage_files = []
+    for root, _, files in os.walk(temp_path):
+        for file in files:
+            if os.path.splitext(file)[1] == ".xstage":
+                xstage_files.append(file)
+
+    if not os.path.basename("temp.zip"):
+        if not xstage_files:
+            self.server.stop()
+            print("no xstage file was found")
+            return
+
+    # try to use first available
+    scene_path = os.path.join(
+        temp_path, xstage_files[0]
+    )
+
+    # prefer the one named as zip file
+    zip_based_name = "{}.xstage".format(
+        os.path.splitext(os.path.basename(filepath))[0])
+
+    for xstage in xstage_files:
+        if zip_based_name in xstage_files:
+            scene_path = os.path.join(
+                temp_path, zip_based_name
+            )
+            break
+
+    if not os.path.exists(scene_path):
+        print("error: cannot determine scene file")
+        self.server.stop()
+        return
+
     print("Launching {}".format(scene_path))
     process = subprocess.Popen([self.application_path, scene_path])
     self.pid = process.pid

--- a/avalon/harmony/lib.py
+++ b/avalon/harmony/lib.py
@@ -130,7 +130,7 @@ def launch_zip_file(filepath):
     # find any xstage files is directory, prefer the one with the same name
     # as directory (plus extension)
     xstage_files = []
-    for root, _, files in os.walk(temp_path):
+    for _, _, files in os.walk(temp_path):
         for file in files:
             if os.path.splitext(file)[1] == ".xstage":
                 xstage_files.append(file)
@@ -150,12 +150,10 @@ def launch_zip_file(filepath):
     zip_based_name = "{}.xstage".format(
         os.path.splitext(os.path.basename(filepath))[0])
 
-    for xstage in xstage_files:
-        if zip_based_name in xstage_files:
-            scene_path = os.path.join(
-                temp_path, zip_based_name
-            )
-            break
+    if zip_based_name in xstage_files:
+        scene_path = os.path.join(
+            temp_path, zip_based_name
+        )
 
     if not os.path.exists(scene_path):
         print("error: cannot determine scene file")


### PR DESCRIPTION
## Problem

Current implementation requires *xstage* file named as workfile zip itself. This doesn't work if artist save scene under different name. In such case there is the error "Scene cannot be found". 

## Solution

This PR is walking through workfile zip, finding all xstage file. There should be only one, but in case there are more, it will prefer the one with the zip file name, otherwise first one it finds.

Closes: pypeclub/pype#526