### PR TITLE
Harmony: add locks to prevent concurrent communication with server

### DIFF
--- a/avalon/harmony/TB_sceneOpened.js
+++ b/avalon/harmony/TB_sceneOpened.js
@@ -118,7 +118,7 @@ function Client()
   self.waitForLock = function() {
     if (self.lock == 0) {
       self.log_debug("Unlocked ...");
-      return
+      return;
     } else {
       setTimeout(self.waitForLock, 300);
     }


### PR DESCRIPTION
## Problem

Sometimes there was race condition when communicating with server. If one process has not finished and user tried to open *Loader* for example, server would still expecting result from previous action but got request for opening Avalon tool instead.

## Solution

This adds locks, so when Harmony is processing something, it will create lock for communication with server. All calls sending request to server will wait until lock is removed.

**Note:** I couldn't test it properly as that race condition never happend on my setup.

🎫 **ticket ID:** [#235](https://support.pype.club/a/tickets/245)
|---|