### PR TITLE
Loader catch load fail and show details

### DIFF
--- a/avalon/tools/libraryloader/widgets.py
+++ b/avalon/tools/libraryloader/widgets.py
@@ -1,3 +1,5 @@
+import sys
+import traceback
 import datetime
 import logging
 import inspect
@@ -323,6 +325,7 @@ class SubsetWidget(loader_widgets.SubsetWidget):
         # same representation available
 
         # Trigger
+        error_info = []
         for item in items:
             version_id = item["version_document"]["_id"]
             representation = self.dbcon.find_one({
@@ -346,7 +349,32 @@ class SubsetWidget(loader_widgets.SubsetWidget):
 
             except pipeline.IncompatibleLoaderError as exc:
                 self.echo(exc)
-                continue
+                error_info.append((
+                    "Incompatible Loader",
+                    None,
+                    representation["name"],
+                    item["subset"],
+                    item["version_document"]["name"]
+                ))
+
+            except Exception as exc:
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                traceback_msg = traceback.extract_tb(exc_traceback)[-1]
+
+                formatted_traceback = "".join(traceback.format_exception(
+                    exc_type, exc_value, exc_traceback
+                ))
+                error_info.append((
+                    str(exc),
+                    formatted_traceback,
+                    representation["name"],
+                    item["subset"],
+                    item["version_document"]["name"]
+                ))
+
+        if error_info:
+            box = loader_widgets.LoadErrorMessageBox(error_info)
+            box.show()
 
     def group_subsets(self, name, asset_id, items):
         field = "data.subsetGroup"

--- a/avalon/tools/libraryloader/widgets.py
+++ b/avalon/tools/libraryloader/widgets.py
@@ -359,8 +359,6 @@ class SubsetWidget(loader_widgets.SubsetWidget):
 
             except Exception as exc:
                 exc_type, exc_value, exc_traceback = sys.exc_info()
-                traceback_msg = traceback.extract_tb(exc_traceback)[-1]
-
                 formatted_traceback = "".join(traceback.format_exception(
                     exc_type, exc_value, exc_traceback
                 ))

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -49,7 +49,7 @@ class LoadErrorMessageBox(QtWidgets.QDialog):
             line = self._create_line()
             body_layout.addWidget(line)
 
-            item_name = item_name_template.format(repre, subset, version)
+            item_name = item_name_template.format(subset, version, repre)
             item_name_widget = QtWidgets.QLabel(
                 item_name.replace("\n", "<br>"), self
             )

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -22,6 +22,69 @@ from .model import (
 )
 
 
+class LoadErrorMessageBox(QtWidgets.QDialog):
+    def __init__(self, messages, parent=None):
+        super(LoadErrorMessageBox, self).__init__(parent)
+        self.setWindowTitle("Loading failed")
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+
+        body_layout = QtWidgets.QVBoxLayout(self)
+
+        main_label = (
+            "<span style='font-size:18pt;'>Failed to load items</span>"
+        )
+        main_label_widget = QtWidgets.QLabel(main_label, self)
+        body_layout.addWidget(main_label_widget)
+
+        item_name_template = (
+            "<span style='font-weight:bold;'>Subset:</span> {}<br>"
+            "<span style='font-weight:bold;'>Version:</span> {}<br>"
+            "<span style='font-weight:bold;'>Representation:</span> {}<br>"
+        )
+        exc_msg_template = "<span style='font-weight:bold'>{}</span>"
+
+        for exc_msg, tb, repre, subset, version in messages:
+            line = self._create_line()
+            body_layout.addWidget(line)
+
+            item_name = item_name_template.format(repre, subset, version)
+            item_name_widget = QtWidgets.QLabel(
+                item_name.replace("\n", "<br>"), self
+            )
+            body_layout.addWidget(item_name_widget)
+
+            exc_msg = exc_msg_template.format(exc_msg.replace("\n", "<br>"))
+            message_label_widget = QtWidgets.QLabel(exc_msg, self)
+            body_layout.addWidget(message_label_widget)
+
+            if tb:
+                tb_widget = QtWidgets.QLabel(tb.replace("\n", "<br>"), self)
+                tb_widget.setTextInteractionFlags(
+                    QtCore.Qt.TextBrowserInteraction
+                )
+                body_layout.addWidget(tb_widget)
+
+        footer_widget = QtWidgets.QWidget(self)
+        footer_layout = QtWidgets.QHBoxLayout(footer_widget)
+        buttonBox = QtWidgets.QDialogButtonBox(QtCore.Qt.Vertical)
+        buttonBox.setStandardButtons(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+        )
+        buttonBox.accepted.connect(self._on_accept)
+        footer_layout.addWidget(buttonBox, alignment=QtCore.Qt.AlignRight)
+        body_layout.addWidget(footer_widget)
+
+    def _on_accept(self):
+        self.close()
+
+    def _create_line(self):
+        line = QtWidgets.QFrame(self)
+        line.setFixedHeight(2)
+        line.setFrameShape(QtWidgets.QFrame.HLine)
+        line.setFrameShadow(QtWidgets.QFrame.Sunken)
+        return line
+
+
 class SubsetWidget(QtWidgets.QWidget):
     """A widget that lists the published subsets for an asset"""
 

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -448,8 +448,6 @@ class SubsetWidget(QtWidgets.QWidget):
 
             except Exception as exc:
                 exc_type, exc_value, exc_traceback = sys.exc_info()
-                traceback_msg = traceback.extract_tb(exc_traceback)[-1]
-
                 formatted_traceback = "".join(traceback.format_exception(
                     exc_type, exc_value, exc_traceback
                 ))


### PR DESCRIPTION
## Issue
- currently loader just crash if loading crash which may cause and issue if we are not in maya or nuke

## Changes
- exceptions are caught and details about crash are shown in popup message box

![image](https://user-images.githubusercontent.com/43494761/94179091-4f7a7480-fe9c-11ea-8a60-6c9107657e64.png)
