### PR TITLE
Harmony: emit signal only after connected to socket

### DIFF
--- a/avalon/harmony/TB_sceneOpened.js
+++ b/avalon/harmony/TB_sceneOpened.js
@@ -98,6 +98,16 @@ function Client()
   {
     self.log_debug("Connected to server.");
     self.socket.readyRead.connect(self.on_ready_read);
+
+    var app = QCoreApplication.instance();
+    app.avalon_client.send(
+      {
+        "module": "avalon.api",
+        "method": "emit",
+        "args": ["application.launched"]
+      },
+      false
+    );
   };
 
   self._send = function(message)
@@ -294,14 +304,6 @@ function start()
 	app.watcher.fileChanged.connect(app.on_file_changed);
   app.avalon_on_file_changed = true;
   */
-  app.avalon_client.send(
-    {
-      "module": "avalon.api",
-      "method": "emit",
-      "args": ["application.launched"]
-    },
-    false
-  );
 }
 
 function TB_sceneOpened()


### PR DESCRIPTION
## Bug:

Fixing race-condition when we are emitting signal `application.launched` possibly before we are connected to socket. This will trigger communication that won't really happen because socket is not ready yet. Result is blocked client-server communication.
