### PR TITLE
Harmony: clear temp scene before opening

### DIFF
--- a/avalon/harmony/lib.py
+++ b/avalon/harmony/lib.py
@@ -75,6 +75,15 @@ def launch(application_path):
     # No launch through Workfiles happened.
     if not self.workfile_path:
         zip_file = os.path.join(os.path.dirname(__file__), "temp.zip")
+        temp_path = get_local_harmony_path(zip_file)
+        if os.path.exists(temp_path):
+            self.log.info(f"removing existing {temp_path}")
+            try:
+                shutil.rmtree(temp_path)
+            except Exception as e:
+                self.log.critical(f"cannot clear {temp_path}")
+                raise Exception(f"cannot clear {temp_path}") from e
+
         launch_zip_file(zip_file)
 
     self.callback_queue = queue.Queue()


### PR DESCRIPTION
## Problem

Empty scene in Harmony is realized by copying and extracting `temp.zip` to `~/.avalon/harmony`. This is never cleared as it is using the same mechanism as with other shots - it is removed and extracted again only if `temp.zip` is newer then extracted directory and that rarely (almost never) happens.

If user doesn't immedietly save empty scene under other name, it will get contaminated with different kinds of things, palettes, audio, etc. This will then persist between all empty scene started later.

##Solution

forcefully removing `~/.avalon/harmony/temp` whenever blank scene is opened.

Fix pypeclub/pype#583