### PR TITLE
Harmony: fix clashing namespace in js function calls

### DIFF
--- a/avalon/harmony/TB_sceneOpened.js
+++ b/avalon/harmony/TB_sceneOpened.js
@@ -45,14 +45,14 @@ function Client()
     {
       try
       {
-        var func = eval.call( null, request["function"]);
+        var _func = eval.call( null, request["function"]);
 
         if (request.args == null)
         {
-          result = func();
+          result = _func();
         }else
         {
-          result = func(request.args);
+          result = _func(request.args);
         }
       }
 

--- a/avalon/harmony/pipeline.py
+++ b/avalon/harmony/pipeline.py
@@ -1,8 +1,12 @@
 from .. import api, pipeline
 from . import lib
 from ..vendor import Qt
+from uuid import uuid4
 
 import pyblish.api
+
+
+signature = str(uuid4())
 
 
 def install():
@@ -49,18 +53,18 @@ class Creator(api.Creator):
     node_type = "COMPOSITE"
 
     def setup_node(self, node):
-        func = """function func(args)
+        func = """function %s_func(args)
         {
             node.setTextAttr(args[0], "COMPOSITE_MODE", 1, "Pass Through");
         }
-        func
-        """
+        %s_func
+        """ % (signature, signature)
         lib.send(
             {"function": func, "args": [node]}
         )
 
     def process(self):
-        func = """function func(args)
+        func = """function %s_func(args)
         {
             var nodes = node.getNodes([args[0]]);
             var node_names = [];
@@ -70,8 +74,8 @@ class Creator(api.Creator):
             }
             return node_names
         }
-        func
-        """
+        %s_func
+        """ % (signature, signature)
 
         existing_node_names = lib.send(
             {"function": func, "args": [self.node_type]}
@@ -87,7 +91,7 @@ class Creator(api.Creator):
                 message_box.exec_()
                 return False
 
-        func = """function func(args)
+        func = """function %s_func(args)
         {
             var result_node = node.add("Top", args[0], args[1], 0, 0, 0);
 
@@ -103,8 +107,8 @@ class Creator(api.Creator):
             }
             return result_node
         }
-        func
-        """
+        %s_func
+        """ % (signature, signature)
 
         with lib.maintained_selection() as selection:
             node = None
@@ -161,7 +165,7 @@ def containerise(name,
         "loader": str(loader),
         "representation": str(context["representation"]["_id"]),
         "nodes": nodes
-        }
+    }
 
     lib.imprint(node, data)
 

--- a/avalon/toonboom/lib.py
+++ b/avalon/toonboom/lib.py
@@ -10,6 +10,7 @@ import subprocess
 import importlib
 import logging
 import filecmp
+from uuid import uuid4
 
 from .server import Server
 from ..tools import workfiles
@@ -28,6 +29,8 @@ self.application_name = None
 # Setup logging.
 self.log = logging.getLogger(__name__)
 self.log.setLevel(logging.DEBUG)
+
+signature = str(uuid4())
 
 
 def execute_in_main_thread(func_to_call_from_main_thread):
@@ -294,7 +297,7 @@ def save_scene():
     """
     # Need to turn off the backgound watcher else the communication with
     # the server gets spammed with two requests at the same time.
-    func = """function func()
+    func = """function %s_func()
     {
         var app = QCoreApplication.instance();
         app.avalon_on_file_changed = false;
@@ -303,19 +306,19 @@ def save_scene():
             scene.currentProjectPath() + "/" + scene.currentVersionName()
         );
     }
-    func
-    """
+    %s_func
+    """ % (signature, signature)
     scene_path = self.send({"function": func})["result"] + "." + self.extension
 
     # Manually update the remote file.
     self.on_file_changed(scene_path)
 
     # Re-enable the background watcher.
-    func = """function func()
+    func = """function %s_func()
     {
         var app = QCoreApplication.instance();
         app.avalon_on_file_changed = true;
     }
-    func
-    """
+    %s_func
+    """ % (signature, signature)
     self.send({"function": func})


### PR DESCRIPTION
## Problem

`func` is already existing object in Harmony namespace. We use `func()` for functions we send from server to Harmony client. When they are eval()ed there, they replace Harmony object making some Hamony functions as *Create keys...*  unusable.

## Solution

Added random **uuid4** prefix for all generated functions by Pype and Avalon core to minimaze possible clash.

🏴 **Relates to similar PR in:** pypeclub/pype#584
|---|