### PR TITLE
Harmony: fix for buffer clearing

### DIFF
--- a/avalon/harmony/TB_sceneOpened.js
+++ b/avalon/harmony/TB_sceneOpened.js
@@ -1,97 +1,108 @@
-function Client()
-{
+/** class implementing avalon client. **/
+function Client() {
   var self = this;
+  /** socket */
   self.socket = new QTcpSocket(this);
+  /** receiving data buffer */
   self.received = "";
+  /** lock */
   self.lock = 1;
 
-  self.log_debug = function(data)
-  {
+  /**
+   * Log message in debug level.
+   * @param {string} data - message
+   */
+  self.log_debug = function(data) {
       message = typeof(data.message) != "undefined" ? data.message : data;
       MessageLog.trace("(DEBUG): " + message.toString());
   };
 
-
-  self.log_info = function(data)
-  {
+  /**
+   * Log message in info level.
+   * @param {string} data - message
+   */
+  self.log_info = function(data) {
       message = typeof(data.message) != "undefined" ? data.message : data;
       MessageLog.trace("(INFO): " + message.toString());
   };
 
-
-  self.log_warning = function(data)
-  {
+  /**
+   * Log message in warning level.
+   * @param {string} data - message
+   */
+  self.log_warning = function(data) {
       message = typeof(data.message) != "undefined" ? data.message : data;
       MessageLog.trace("(WARNING): " + message.toString());
   };
 
-
-  self.log_error = function(data)
-  {
+  /**
+   * Log message in error level.
+   * @param {string} data - message
+   */
+  self.log_error = function(data) {
       message = typeof(data.message) != "undefined" ? data.message : data;
       MessageLog.trace("(ERROR): " + message.toString());
   };
 
-  self.show_message = function(msg)
-  {
+  /**
+   * Show message in Harmony GUI as popup window.
+   * @param {string} msg - message
+   */
+  self.show_message = function(msg) {
     MessageBox.information(msg);
   };
 
-  self.process_request = function(request)
-  {
+  /**
+   * Process recieved request. This will eval recieved function and produce
+   * results.
+   * @param {object} request - recieved request JSON
+   * @return {object} result of evaled function.
+   */
+  self.process_request = function(request) {
     self.log_debug("Processing: " + JSON.stringify(request));
     var result = null;
 
-    if (request["function"] != null)
-    {
-      try
-      {
+    if (request["function"] != null) {
+      try {
         var _func = eval.call( null, request["function"]);
 
-        if (request.args == null)
-        {
+        if (request.args == null) {
           result = _func();
-        }else
-        {
+        } else {
           result = _func(request.args);
         }
-      }
-
-      catch (error)
-      {
-        result = "Error processing request.\nRequest:\n" + JSON.stringify(request) + "\nError:\n" + error;
+      } catch (error) {
+        result = "Error processing request.\n" +
+                 "Request:\n" +
+                 JSON.stringify(request) + "\n" +
+                 "Error:\n" + error;
       }
     }
-
     return result;
   };
 
-  self.on_ready_read = function()
-  {
-    self.log_debug("Receiving data...");
+  /**
+   * Executed when receiving data to socket.
+   */
+  self.on_ready_read = function() {
+    self.log_debug("Receiving data ...");
     self.log_debug("Locking ...");
     self.lock = 1;
     data = self.socket.readAll();
 
-    if (data.size() != 0)
-    {
-      for ( var i = 0; i < data.size(); ++i)
-      {
+    if (data.size() != 0) {
+      for ( var i = 0; i < data.size(); ++i) {
         self.received = self.received.concat(String.fromCharCode(data.at(i)));
       }
     }
-
     self.log_debug("Received: " + self.received);
-
 
     request = JSON.parse(self.received);
 
     self.log_debug("Request: " + JSON.stringify(request));
 
     request.result = self.process_request(request);
-
-    if (!request.reply)
-    {
+    if (!request.reply) {
       request.reply = true;
       self._send(JSON.stringify(request));
     }
@@ -101,26 +112,24 @@ function Client()
     self.lock = 0;
   };
 
-  self.on_connected = function()
-  {
-    self.log_debug("Connected to server.");
+  /**
+   * Executed when connected to server.
+   */
+  self.on_connected = function() {
+    self.log_debug("Connected to server ...");
     self.lock = 0;
     self.socket.readyRead.connect(self.on_ready_read);
 
     var app = QCoreApplication.instance();
 
-    app.avalon_client.send(
-      {
+    app.avalon_client.send({
         "module": "avalon.api",
         "method": "emit",
         "args": ["application.launched"]
-      },
-      false
-    );
+      }, false);
   };
 
-  self._send = function(message)
-  {
+  self._send = function(message) {
     self.log_debug("Sending: " + message);
 
     var data = new QByteArray();
@@ -133,7 +142,9 @@ function Client()
     self.socket.write(codec.fromUnicode(message));
   };
 
-
+  /**
+   * Timer to block until lock is released.
+   */
   self.waitForLock = function() {
     if (self.lock == 0) {
       self.log_debug("Unlocked ...");
@@ -143,8 +154,12 @@ function Client()
     }
   };
 
-  self.send = function(request, wait)
-  {
+  /**
+   * Send request to server.
+   * @param {object} request - json encoded request.
+   * @param {bool} wait - wait for reply.
+   */
+  self.send = function(request, wait) {
     if (self.lock !== 0) {
       self.log_debug("Still locked, waiting for unlock ...");
       self.waitForLock();
@@ -152,27 +167,29 @@ function Client()
 
     self._send(JSON.stringify(request));
 
-    while (wait)
-    {
-      try
-      {
+    // buffer self.recieved is cleared by on_ready_read()
+    // Nothing except it should modify this buffer.
+    while (wait) {
+      try {
         JSON.parse(self.received);
         break;
-      }
-      catch(err)
-      {
+      } catch(err) {
         self.socket.waitForReadyRead(5000);
       }
     }
-
-    self.received = "";
   };
 
+  /**
+   * Executed on disconnection.
+   */
   self.on_disconnected = function()
   {
     self.socket.close();
   };
 
+  /**
+   * Disconnect from server.
+   */
   self.disconnect = function()
   {
     self.socket.close();
@@ -182,17 +199,20 @@ function Client()
   self.socket.disconnected.connect(self.on_disconnected);
 }
 
-function start()
-{
+/**
+ * Entry point, creating Avalon Client.
+ */
+function start() {
   var self = this;
+  /** hostname or ip of server - should be localhost */
   var host = "127.0.0.1";
+  /** port of the server */
   var port = parseInt(System.getenv("AVALON_HARMONY_PORT"));
 
   // Attach the client to the QApplication to preserve.
   var app = QCoreApplication.instance();
 
-  if (app.avalon_client == null)
-  {
+  if (app.avalon_client == null) {
     app.avalon_client = new Client();
     app.avalon_client.socket.connectToHost(host, port);
   }
@@ -200,99 +220,95 @@ function start()
 	var menu_bar = QApplication.activeWindow().menuBar();
 	var actions = menu_bar.actions();
 	app.avalon_menu = null;
-	for (var i = 0 ; i < actions.length; i++)
-	{
-    if (actions[i].text == "Avalon")
-    {
+
+	for (var i = 0 ; i < actions.length; i++) {
+    if (actions[i].text == "Avalon") {
       app.avalon_menu = true;
     }
   }
 
   var menu = null;
-	if (app.avalon_menu == null)
-	{
+	if (app.avalon_menu == null) {
     var menu = menu_bar.addMenu("Avalon");
   }
 
-  self.on_creator = function()
-  {
-    app.avalon_client.send(
-      {
+  /**
+   * Show creator
+   */
+  self.on_creator = function() {
+    app.avalon_client.send({
         "module": "avalon.harmony.lib",
         "method": "show",
         "args": ["avalon.tools.creator"]
-      },
-      false
-    );
+      }, false);
   };
-	if (app.avalon_menu == null)
-	{
+  // Add creator item to menu
+	if (app.avalon_menu == null) {
     var action = menu.addAction("Create...");
     action.triggered.connect(self.on_creator);
 	}
 
-  self.on_workfiles = function()
-  {
-    app.avalon_client.send(
-      {
+  /**
+   * Show Workfiles
+   */
+  self.on_workfiles = function() {
+    app.avalon_client.send({
         "module": "avalon.harmony.lib",
         "method": "show",
         "args": ["avalon.tools.workfiles"]
-      },
-      false
-    );
+      }, false);
   };
+  // Add workfiles item to menu
 	if (app.avalon_menu == null)
 	{
     action = menu.addAction("Workfiles");
     action.triggered.connect(self.on_workfiles);
 	}
 
-  self.on_load = function()
-  {
-    app.avalon_client.send(
-        {
+  /**
+   * Show Loader
+   */
+  self.on_load = function() {
+    app.avalon_client.send({
           "module": "avalon.harmony.lib",
           "method": "show",
           "args": ["avalon.tools.loader"]
-        },
-        false
-    );
+        }, false);
   };
-	if (app.avalon_menu == null)
-	{
+  // add Loader item to menu
+	if (app.avalon_menu == null) {
     action = menu.addAction("Load...");
     action.triggered.connect(self.on_load);
 	}
 
-  self.on_publish = function()
-  {
-    app.avalon_client.send(
-        {
+  /**
+   * Show Publisher
+   */
+  self.on_publish = function() {
+    app.avalon_client.send({
           "module": "avalon.harmony.lib",
           "method": "show",
           "args": ["avalon.tools.publish"]
-        },
-        false
-    );
+        }, false);
   };
+  // add Publisher item to menu
 	if (app.avalon_menu == null)
 	{
     action = menu.addAction("Publish...");
     action.triggered.connect(self.on_publish);
 	}
 
-  self.on_manage = function()
-  {
-    app.avalon_client.send(
-        {
+  /**
+   * Show Scene Manager
+   */
+  self.on_manage = function() {
+    app.avalon_client.send({
           "module": "avalon.harmony.lib",
           "method": "show",
           "args": ["avalon.tools.sceneinventory"]
-        },
-        false
-    );
+        }, false);
   };
+  // add Scene Manager item to menu
 	if (app.avalon_menu == null)
 	{
     action = menu.addAction("Manage...");
@@ -328,6 +344,9 @@ function start()
 	app.watcher.fileChanged.connect(app.on_file_changed);
   app.avalon_on_file_changed = true;
   */
+  app.on_file_changed = function(path) {
+
+  }
 }
 
 function TB_sceneOpened()

--- a/avalon/harmony/TB_sceneOpened.js
+++ b/avalon/harmony/TB_sceneOpened.js
@@ -345,8 +345,8 @@ function start() {
   app.avalon_on_file_changed = true;
   */
   app.on_file_changed = function(path) {
-
-  }
+    // empty stub
+  };
 }
 
 function TB_sceneOpened()


### PR DESCRIPTION
## Problem

in some casis `received` buffer could be cleared by `send()` function during receiving incoming request from server. In that case `JSON.parse(received)` could break.

### Additional changes

Added docstrings and made code more compact