### PR TITLE
Harmony: Disable auto setting of scene

### DIFF
--- a/avalon/harmony/TB_sceneOpened.js
+++ b/avalon/harmony/TB_sceneOpened.js
@@ -349,6 +349,18 @@ function start() {
   };
 }
 
+function ensureSceneSettings() {
+  var app = QCoreApplication.instance();
+  app.avalon_client.send(
+    {
+      "module": "pype.hosts.harmony",
+      "method": "ensure_scene_settings",
+      "args": []
+    },
+    false
+  );
+}
+
 function TB_sceneOpened()
 {
   start();


### PR DESCRIPTION
## Problem

Automatic call to `pype.hosts.harmony.ensure_scene_settings()` resulted in communication problems between client <-> server.
Similar PR to pypeclub/pype#637 is disabling this functionality in Pype, this PR is promoting separate function to be added to Harmony toolbar to allow user for manuall call.

![harmony_scripting](https://user-images.githubusercontent.com/33513211/95995397-b7840100-0e31-11eb-8826-1385c0d30368.gif)

🏴 **dependes on:** pypeclub/pype#637
|---|