### PR TITLE
QArgparse fix of toggleable button

### DIFF
--- a/avalon/vendor/qargparse.py
+++ b/avalon/vendor/qargparse.py
@@ -8,6 +8,7 @@ import logging
 
 from collections import OrderedDict as odict
 from .Qt import QtCore, QtWidgets, QtGui
+from . import qtawesome
 
 __version__ = "0.5.2"
 _log = logging.getLogger(__name__)
@@ -135,7 +136,8 @@ class QArgumentParser(QtWidgets.QWidget):
             else QtWidgets.QLabel()
         )
         widget = arg.create()
-        reset = QtWidgets.QPushButton("")  # default
+        icon = qtawesome.icon("fa.refresh", color="white")
+        reset = QtWidgets.QPushButton(icon, "")  # default
         reset.setToolTip("Reset")
         reset.setProperty("type", "reset")
         reset.clicked.connect(lambda: self.on_reset(arg))

--- a/avalon/vendor/qargparse.py
+++ b/avalon/vendor/qargparse.py
@@ -515,10 +515,16 @@ class Button(QArgument):
 
         if isinstance(self, Toggle):
             widget.setCheckable(True)
-            self._read = lambda: widget.checkState()
-            self._write = (
-                lambda value: widget.setCheckState(state[int(value)])
-            )
+            if hasattr(widget, "isChecked"):
+                self._read = lambda: state[int(widget.isChecked())]
+                self._write = (
+                    lambda value: widget.setChecked(value)
+                )
+            else:
+                self._read = lambda: widget.checkState()
+                self._write = (
+                    lambda value: widget.setCheckState(state[int(value)])
+                )
         else:
             self._read = lambda: "clicked"
             self._write = lambda value: None


### PR DESCRIPTION
## Issue
- Few Qt bindings do not support checkState on `QPushButton` (`checkState` & `setCheckState` methods)

## Changes
- For these bindings was added check if widget has attribute `isChecked` in that case are used methods: `isChecked` and `setChecked`
- added icon to reset button so user can imagine why is there
![image](https://user-images.githubusercontent.com/43494761/97978147-71d1ad00-1dcd-11eb-94d7-ec9a003e9bc5.png)
