### PR TITLE
Set current asset in switcher as default.

### DIFF
--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -748,6 +748,15 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
         self.setMinimumWidth(self.MIN_WIDTH)
 
+        # Set initial asset as current.
+        index = self._assets_box.findText(
+            api.Session["AVALON_ASSET"], QtCore.Qt.MatchFixedString
+        )
+        print("asset box index", index)
+        if index >= 0:
+            print("setting asset box")
+            self._assets_box.setCurrentIndex(index)
+
         # Set default focus to accept button so you don't directly type in
         # first asset field, this also allows to see the placeholder value.
         accept_btn.setFocus()


### PR DESCRIPTION
This PR initially set the current asset as default when launching the Asset Switcher. In most cases we find that this is the asset we want, so typing this in takes a bit of time.