### PR TITLE
Avoid multiple asset fetch

### DIFF
--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -293,6 +293,7 @@ class Window(QtWidgets.QDialog):
         assert project, "This is a bug"
 
         assets_widget = self.data["widgets"]["assets"]
+        assets_widget.model.stop_fetch_thread()
         assets_widget.refresh()
         assets_widget.setFocus()
 


### PR DESCRIPTION
## Issue
- asset model can have running multiple threads fetching asset documents which is inefficient and cause duplicated items in asset view

## Changes
- fetch is skipped if fetch thread is already running
- library loader has to stop fetch manually on project change as running fetch thread may be still running but for different project