### PR TITLE
Asset fetch second fix

### DIFF
--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -452,7 +452,6 @@ class AssetModel(TreeModel):
         assets_by_parent = self._doc_payload.get("assets_by_parent")
         silos = self._doc_payload.get("silos")
         if assets_by_parent is not None:
-
             # Build the hierarchical tree items recursively
             self._add_hierarchy(
                 assets_by_parent,
@@ -461,9 +460,11 @@ class AssetModel(TreeModel):
             )
 
         self.endResetModel()
-        has_content = bool(assets_by_parent) or bool(silos)
 
+        has_content = bool(assets_by_parent) or bool(silos)
         self.refreshed.emit(has_content)
+
+        self.stop_fetch_thread()
 
     def fetch(self):
         self._doc_payload = self._fetch() or {}
@@ -510,6 +511,7 @@ class AssetModel(TreeModel):
             self._doc_fetching_stop = True
             while self._doc_fetching_thread.isRunning():
                 time.sleep(0.001)
+            self._doc_fetching_thread = None
 
     def refresh(self):
         """Refresh the data for the model."""

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -468,6 +468,7 @@ class AssetModel(TreeModel):
 
     def fetch(self):
         self._doc_payload = self._fetch() or {}
+        # Emit doc fetched only if was not stopped
         self.doc_fetched.emit(self._doc_fetching_stop)
 
     def _fetch(self):
@@ -513,14 +514,13 @@ class AssetModel(TreeModel):
                 time.sleep(0.001)
             self._doc_fetching_thread = None
 
-    def refresh(self):
+    def refresh(self, force=False):
         """Refresh the data for the model."""
         # Skip fetch if there is already other thread fetching documents
-        if (
-            self._doc_fetching_thread is not None
-            and self._doc_fetching_thread.isRunning()
-        ):
-            return
+        if self._doc_fetching_thread is not None:
+            if not force:
+                return
+            self.stop_fetch_thread()
 
         # Clear model items
         self.clear()

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -443,6 +443,10 @@ class AssetModel(TreeModel):
             self.asset_colors[asset["_id"]] = []
 
     def on_doc_fetched(self, was_stopped):
+        if was_stopped:
+            self.stop_fetch_thread()
+            return
+
         self.beginResetModel()
 
         assets_by_parent = self._doc_payload.get("assets_by_parent")

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -1,4 +1,5 @@
 import re
+import time
 import logging
 import collections
 
@@ -504,7 +505,7 @@ class AssetModel(TreeModel):
         if self._doc_fetching_thread is not None:
             self._doc_fetching_stop = True
             while self._doc_fetching_thread.isRunning():
-                pass
+                time.sleep(0.001)
 
     def refresh(self):
         """Refresh the data for the model."""

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -341,7 +341,7 @@ class AssetModel(TreeModel):
     ObjectIdRole = QtCore.Qt.UserRole + 3
     subsetColorsRole = QtCore.Qt.UserRole + 4
 
-    doc_fetched = QtCore.Signal()
+    doc_fetched = QtCore.Signal(bool)
     refreshed = QtCore.Signal(bool)
 
     # Asset document projection
@@ -442,7 +442,7 @@ class AssetModel(TreeModel):
 
             self.asset_colors[asset["_id"]] = []
 
-    def on_doc_fetched(self):
+    def on_doc_fetched(self, was_stopped):
         self.beginResetModel()
 
         assets_by_parent = self._doc_payload.get("assets_by_parent")
@@ -463,7 +463,7 @@ class AssetModel(TreeModel):
 
     def fetch(self):
         self._doc_payload = self._fetch() or {}
-        self.doc_fetched.emit()
+        self.doc_fetched.emit(self._doc_fetching_stop)
 
     def _fetch(self):
         if not self.dbcon.Session.get("AVALON_PROJECT"):

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -26,6 +26,7 @@ class AssetWidget(QtWidgets.QWidget):
     """
 
     refresh_triggered = QtCore.Signal()   # on model refresh
+    refreshed = QtCore.Signal()
     selection_changed = QtCore.Signal()  # on view selection change
     current_changed = QtCore.Signal()    # on view current index change
 
@@ -100,6 +101,7 @@ class AssetWidget(QtWidgets.QWidget):
             self.set_loading_state(loading=False, empty=not has_item)
             self._restore_model_selection()
             self.model.refreshed.disconnect()
+            self.refreshed.emit()
             print("Duration: %.3fs" % (time.time() - time_start))
 
         self.model.refreshed.connect(on_refreshed)

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -257,6 +257,10 @@ class AssetWidget(QtWidgets.QWidget):
                     # Ensure item is visible
                     self.view.scrollTo(index)
                     selection_model.select(index, flags)
+        else:
+            asset_name = self.dbcon.Session.get("AVALON_ASSET")
+            if asset_name:
+                self.select_assets([asset_name])
 
 
 class OptionalMenu(QtWidgets.QMenu):

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -226,8 +226,13 @@ class AssetWidget(QtWidgets.QWidget):
 
     def _restore_model_selection(self):
         model = self.view.model()
-        expanded = self.model_selection.pop("expanded", None)
-        selected = self.model_selection.pop("selected", None)
+        not_set = object()
+        expanded = self.model_selection.pop("expanded", not_set)
+        selected = self.model_selection.pop("selected", not_set)
+
+        if expanded is not_set or selected is not_set:
+            return
+
         if expanded:
             for index in lib.iter_model_rows(
                 model, column=0, include_root=False


### PR DESCRIPTION
## Issue
- previous fix did it's job but worked only on very fast queries, which is not ideal (https://github.com/pypeclub/avalon-core/pull/221)

## Changes
- refresh of assets is not possible if attribute `_doc_fetching_thread` is not set to `None`
    - this requires to set `_doc_fetching_thread` to `None` after all processing which is handled
- do not fill any items to model if fetching was stopped

|:black_flag: |this depends on|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/726|