### PR TITLE
Font size in points

### DIFF
--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -37,7 +37,8 @@ QWidget
     background-clip: border;
     border-image: none;
     outline: 0;
-    font-size: 12px;
+    /*font-size: 12px;*/
+    font-size: 9pt;
 }
 
 QWidget:item:hover
@@ -1252,7 +1253,8 @@ QSplitter {
 }
 
 #IconView[mode="icon"] {
-    font-size: 11px;
+    /*font-size: 11px;*/
+    font-size: 8pt;
     border: 0px;
     padding: 0px;
     margin: 0px;


### PR DESCRIPTION
## Description
Current stylesheets set font size in pixels which is not scaled properly if Qt autoscaling is not working on 4k resolution. But is scaled properly when set in points (specifically in Maya).

## Changes
- changed global font size in style from `12px` to `9pt` and from `11px` to `8pt` in one specific object name