### PR TITLE
TVPaint update fix

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -190,6 +190,9 @@ class Loader(list):
     order = 0
 
     def __init__(self, context):
+        self.fname = self.filepath_from_context(context)
+
+    def filepath_from_context(self, context):
         representation = context['representation']
         project_doc = context.get("project")
         root = None
@@ -198,7 +201,7 @@ class Loader(list):
             anatomy = Anatomy(project_doc["name"])
             root = anatomy.roots_obj
 
-        self.fname = get_representation_path(representation, root)
+        return get_representation_path(representation, root)
 
     def load(self, context, name=None, namespace=None, options=None):
         """Load asset via database

--- a/avalon/tvpaint/communication_server.py
+++ b/avalon/tvpaint/communication_server.py
@@ -792,7 +792,7 @@ class Communicator:
         try:
             self._windows_copy(to_copy)
         except Exception:
-            pass
+            log.error("Plugin copy failed", exc_info=True)
 
         # Validate copy was done
         invalid = []
@@ -801,12 +801,17 @@ class Communicator:
                 invalid.append((src, dst))
 
         if invalid:
-            raise RuntimeError("Copying of plugin was not successfull")
+            _invalid = []
+            for src, dst in invalid:
+                _invalid.append("\"{}\" -> \"{}\"".format(src, dst))
+
+            raise RuntimeError(
+                "Copy of plugin files failed. Failed files {}".format(
+                    ", ".join(_invalid)
+                )
+            )
 
     def _launch_tv_paint(self, launch_args):
-        if platform.system().lower() == "windows":
-            self._prepare_windows_plugin(launch_args)
-
         flags = (
             subprocess.DETACHED_PROCESS
             | subprocess.CREATE_NEW_PROCESS_GROUP
@@ -825,6 +830,9 @@ class Communicator:
         """
         log.info("Installing TVPaint implementation")
         api.install(tvpaint)
+
+        if platform.system().lower() == "windows":
+            self._prepare_windows_plugin(launch_args)
 
         # Launch TVPaint and the websocket server.
         log.info("Launching TVPaint")

--- a/avalon/tvpaint/communication_server.py
+++ b/avalon/tvpaint/communication_server.py
@@ -880,7 +880,7 @@ class Communicator:
     def _initial_textfile_write(self):
         """Show popup about Write to file at start of TVPaint."""
         tmp_file = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".txt", delete=False
+            mode="w", prefix="a_tvp_", suffix=".txt", delete=False
         )
         tmp_file.close()
         tmp_filepath = tmp_file.name.replace("\\", "/")

--- a/avalon/tvpaint/lib.py
+++ b/avalon/tvpaint/lib.py
@@ -21,7 +21,7 @@ def execute_george_through_file(george_script):
         george_script (str): George script to execute. May be multilined.
     """
     temporary_file = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".grg", delete=False
+        mode="w", prefix="a_tvp_", suffix=".grg", delete=False
     )
     temporary_file.write(george_script)
     temporary_file.close()
@@ -65,7 +65,7 @@ def parse_layers_data(data):
 
 def layers_data(layer_ids=None):
     output_file = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".txt", delete=False
+        mode="w", prefix="a_tvp_", suffix=".txt", delete=False
     )
     output_file.close()
     if layer_ids is not None and isinstance(layer_ids, int):
@@ -170,7 +170,7 @@ def parse_group_data(data):
 
 def groups_data():
     output_file = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".txt", delete=False
+        mode="w", prefix="a_tvp_", suffix=".txt", delete=False
     )
     output_file.close()
 
@@ -220,7 +220,7 @@ def get_exposure_frames(layer_id, first_frame=None, last_frame=None):
             last_frame = layer["frame_end"]
 
     tmp_file = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".txt", delete=False
+        mode="w", prefix="a_tvp_", suffix=".txt", delete=False
     )
     tmp_file.close()
     tmp_output_path = tmp_file.name.replace("\\", "/")

--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -126,7 +126,7 @@ def workfile_metadata(metadata_key, default=None):
         .replace("{__sq__}", "'")
         .replace("{__dq__}", "\"")
     )
-
+    os.remove(output_filepath)
     if json_string:
         return json.loads(json_string)
     return default

--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -106,7 +106,7 @@ def workfile_metadata(metadata_key, default=None):
     if default is None:
         default = []
     output_file = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".txt", delete=False
+        mode="w", prefix="a_tvp_", suffix=".txt", delete=False
     )
     output_file.close()
 


### PR DESCRIPTION
## Changes
- class `Loader` has new method `filepath_from_context` which does what was in `__init__` of Loader but this way is accessible and usable anytime in loader object
- moved plugin copy before websocket server has started so opened python process won't get stuck on error
- remove temporary file with workfile metadata
- temporary files has prefix now

|:black_flag: |this depends on|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/752|