### PR TITLE
TVPaint store context to workfile metadata (764)

### DIFF
--- a/avalon/tvpaint/__init__.py
+++ b/avalon/tvpaint/__init__.py
@@ -5,6 +5,7 @@ from .pipeline import (
     install,
     uninstall,
     maintained_selection,
+    get_current_workfile_context,
     ls,
     Creator,
     Loader

--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -92,7 +92,7 @@ def maintained_selection():
         pass
 
 
-def workfile_metadata(metadata_key, default=None):
+def get_workfile_metadata(metadata_key, default=None):
     """Read metadata for specific key from current project workfile.
 
     Pipeline use function to store loaded and created instances within keys
@@ -163,7 +163,7 @@ def write_workfile_metadata(metadata_key, value):
 
 
 def list_instances():
-    return workfile_metadata(SECTION_NAME_INSTANCES)
+    return get_workfile_metadata(SECTION_NAME_INSTANCES)
 
 
 def _write_instances(data):
@@ -171,7 +171,7 @@ def _write_instances(data):
 
 
 def ls():
-    return workfile_metadata(SECTION_NAME_CONTAINERS)
+    return get_workfile_metadata(SECTION_NAME_CONTAINERS)
 
 
 class Creator(api.Creator):

--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -12,6 +12,7 @@ from ..pipeline import AVALON_CONTAINER_ID
 
 
 METADATA_SECTION = "avalon"
+SECTION_NAME_CONTEXT = "context"
 SECTION_NAME_INSTANCES = "instances"
 SECTION_NAME_CONTAINERS = "containers"
 
@@ -160,6 +161,16 @@ def write_workfile_metadata(metadata_key, value):
         "tv_writeprojectstring \"{}\" \"{}\" \"{}\""
     ).format(METADATA_SECTION, metadata_key, value)
     return lib.execute_george_through_file(george_script)
+
+
+def get_current_workfile_context():
+    """Return context in which was workfile saved."""
+    return get_workfile_metadata(SECTION_NAME_CONTEXT, {})
+
+
+def save_current_workfile_context(context):
+    """Save context which was used to create a workfile."""
+    return write_workfile_metadata(SECTION_NAME_CONTEXT, context)
 
 
 def list_instances():

--- a/avalon/tvpaint/workio.py
+++ b/avalon/tvpaint/workio.py
@@ -8,6 +8,7 @@
 
 from avalon import api
 from . import CommunicationWrapper
+from . pipeline import save_current_workfile_context
 
 
 def open_file(filepath):
@@ -18,8 +19,18 @@ def open_file(filepath):
 
 def save_file(filepath):
     """Save the open scene file."""
+    # Execute george script to save workfile.
     george_script = "tv_SaveProject {}".format(filepath.replace("\\", "/"))
-    return CommunicationWrapper.execute_george(george_script)
+    result = CommunicationWrapper.execute_george(george_script)
+
+    # Store context to created workfile
+    context = {
+        "project": api.Session["AVALON_PROJECT"],
+        "asset": api.Session["AVALON_ASSET"],
+        "task": api.Session["AVALON_TASK"]
+    }
+    save_current_workfile_context(context)
+    return result
 
 
 def current_file():

--- a/avalon/tvpaint/workio.py
+++ b/avalon/tvpaint/workio.py
@@ -19,18 +19,17 @@ def open_file(filepath):
 
 def save_file(filepath):
     """Save the open scene file."""
-    # Execute george script to save workfile.
-    george_script = "tv_SaveProject {}".format(filepath.replace("\\", "/"))
-    result = CommunicationWrapper.execute_george(george_script)
-
-    # Store context to created workfile
+    # Store context to workfile before save
     context = {
         "project": api.Session["AVALON_PROJECT"],
         "asset": api.Session["AVALON_ASSET"],
         "task": api.Session["AVALON_TASK"]
     }
     save_current_workfile_context(context)
-    return result
+
+    # Execute george script to save workfile.
+    george_script = "tv_SaveProject {}".format(filepath.replace("\\", "/"))
+    return CommunicationWrapper.execute_george(george_script)
 
 
 def current_file():


### PR DESCRIPTION
## Issue
It is possible to have opened multiple workfiles at the same time from different contexts. Which is not an issue for most of avalon workflow but is issue for publishing.

## Changes
Each workfile contain metadata with `"project"`, `"asset"` and `"task"` to keep context in which were workfiles created.

|:black_flag: |this depends on|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/765|