### PR TITLE
TVPaint store members key

### DIFF
--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -59,14 +59,11 @@ def containerise(
     Returns:
         dict: Container data stored to workfile metadata.
     """
-    # Convert ids to string
-    layer_ids = [str(layer_id) for layer_id in layer_ids]
-    object_name = "|".join(layer_ids)
 
     container_data = {
         "schema": "avalon-core:container-2.0",
         "id": AVALON_CONTAINER_ID,
-        "objectName": object_name,
+        "members": layer_ids,
         "name": name,
         "namespace": namespace,
         "loader": str(loader),
@@ -257,9 +254,13 @@ class Loader(api.Loader):
 
     @staticmethod
     def layer_ids_from_container(container):
-        layer_ids_str = container["objectName"]
-        layer_ids = [int(layer_id) for layer_id in layer_ids_str.split("|")]
-        return layer_ids
+        if "members" not in container and "objectName" in container:
+            # Backwards compatibility
+            layer_ids_str = container.get("objectName")
+            return [
+                int(layer_id) for layer_id in layer_ids_str.split("|")
+            ]
+        return container["members"]
 
     def get_unique_layer_name(self, asset_name, name):
         """Layer name with counter as suffix.


### PR DESCRIPTION
## Changes
- store layer ids to `"members"` keys instead of `"objectName"`
- kept backwards compatibility if `layer_ids_from_container` method is used to get layer ids from container

|:black_flag: |this depends on|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/769|