### PR TITLE
Remove pype presets from library loader

### DIFF
--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -10,7 +10,7 @@ from ... import api, io, style
 
 from .widgets import CreateErrorMessageBox
 from .. import lib
-from pype.api import config
+from pype.api import get_current_project_settings
 
 module = sys.modules[__name__]
 module.window = None
@@ -451,12 +451,18 @@ class Window(QtWidgets.QDialog):
             item.setData(QtCore.Qt.ItemIsEnabled, False)
             listing.addItem(item)
 
-        config_data = config.get_presets()["tools"]["creator"]
+        pype_project_setting = (
+            get_current_project_settings()
+            ["global"]
+            ["tools"]
+            ["creator"]
+            ["families_smart_select"]
+        )
         item = None
         family_type = None
         task_name = io.Session.get('AVALON_TASK', None)
         if task_name:
-            for key, value in config_data.items():
+            for key, value in pype_project_setting.items():
                 for t_name in value:
                     if t_name in task_name.lower():
                         family_type = key

--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -168,8 +168,6 @@ class Window(QtWidgets.QDialog):
         projects = self.get_filtered_projects()
 
         project_name = self.combo_projects.currentText()
-        if default:
-            project_name = self.get_default_project()
 
         self.combo_projects.clear()
         if len(projects) > 0:
@@ -223,27 +221,6 @@ class Window(QtWidgets.QDialog):
         title = "{} - {}".format(self.tool_title, project_name)
         self.setWindowTitle(title)
 
-    def get_default_project(self):
-        # looks into presets if any default library is set
-        # - returns name of library from presets if exists in db
-        # - if was not found or not set then returns first existing project
-        # - returns `None` if any project was found in db
-        name = None
-        presets = config.get_presets().get("tools", {}).get(
-            "library_loader", {}
-        )
-        if self.show_projects:
-            name = presets.get("default_project")
-        if self.show_libraries and not name:
-            name = presets.get("default_library")
-
-        projects = self.get_filtered_projects()
-
-        if name and name in projects:
-            return name
-        elif len(projects) > 0:
-            return projects[0]
-        return None
 
     @property
     def current_project(self):


### PR DESCRIPTION
This removes presets from library loader. It was used to pick default library, however the it introduced pype dependency to core, for very little benefit