### PR TITLE
remove pype presest from workfiles launching

### DIFF
--- a/avalon/api.py
+++ b/avalon/api.py
@@ -63,7 +63,6 @@ from .pipeline import (
     deregister_plugin_path,
 
     HOST_WORKFILE_EXTENSIONS,
-    should_start_last_workfile,
     format_template_with_optional_keys,
     last_workfile_with_version,
     last_workfile

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -408,61 +408,6 @@ def should_start_last_workfile(project_name, host_name, task_name):
         elif env_override in ("false", "no", "0"):
             default_output = False
 
-    try:
-        from pype.api import config
-        startup_presets = (
-            config.get_presets(project_name)
-            .get("tools", {})
-            .get("workfiles", {})
-            .get("last_workfile_on_startup")
-        )
-    except Exception:
-        startup_presets = None
-        log.warning("Couldn't load pype's presets", exc_info=True)
-
-    if not startup_presets:
-        return default_output
-
-    host_name_lowered = host_name.lower()
-    task_name_lowered = task_name.lower()
-
-    max_points = 2
-    matching_points = -1
-    matching_item = None
-    for item in startup_presets:
-        hosts = item.get("hosts") or tuple()
-        tasks = item.get("tasks") or tuple()
-
-        hosts_lowered = tuple(_host_name.lower() for _host_name in hosts)
-        # Skip item if has set hosts and current host is not in
-        if hosts_lowered and host_name_lowered not in hosts_lowered:
-            continue
-
-        tasks_lowered = tuple(_task_name.lower() for _task_name in tasks)
-        # Skip item if has set tasks and current task is not in
-        if tasks_lowered:
-            task_match = False
-            for task_regex in compile_list_of_regexes(tasks_lowered):
-                if re.match(task_regex, task_name_lowered):
-                    task_match = True
-                    break
-
-            if not task_match:
-                continue
-
-        points = int(bool(hosts_lowered)) + int(bool(tasks_lowered))
-        if points > matching_points:
-            matching_item = item
-            matching_points = points
-
-        if matching_points == max_points:
-            break
-
-    if matching_item is not None:
-        output = matching_item.get("enabled")
-        if output is None:
-            output = default_output
-        return output
     return default_output
 
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -361,56 +361,6 @@ class InventoryAction(object):
         return True
 
 
-def compile_list_of_regexes(in_list):
-    """Convert strings in entered list to compiled regex objects."""
-    regexes = list()
-    if not in_list:
-        return regexes
-
-    for item in in_list:
-        if item:
-            try:
-                regexes.append(re.compile(item))
-            except TypeError:
-                log.warning((
-                    "Invalid type \"{}\" value \"{}\"."
-                    " Expected string based object. Skipping."
-                ).format(str(type(item)), str(item)))
-    return regexes
-
-
-def should_start_last_workfile(project_name, host_name, task_name):
-    """Define if host should start last version workfile if possible.
-
-    Default output is `False`. Can be overriden with environment variable
-    `AVALON_OPEN_LAST_WORKFILE`, valid values without case sensitivity are
-    `"0", "1", "true", "false", "yes", "no"`.
-
-    Args:
-        project_name (str): Name of project.
-        host_name (str): Name of host which is launched. In avalon's
-            application context it's value stored in app definition under
-            key `"application_dir"`. Is not case sensitive.
-        task_name (str): Name of task which is used for launching the host.
-            Task name is not case sensitive.
-
-    Returns:
-        bool: True if host should start workfile.
-
-    """
-    default_output = False
-
-    env_override = os.environ.get("AVALON_OPEN_LAST_WORKFILE")
-    if env_override is not None:
-        env_override = env_override.lower().strip()
-        if env_override in ("true", "yes", "1"):
-            default_output = True
-        elif env_override in ("false", "no", "0"):
-            default_output = False
-
-    return default_output
-
-
 class Application(Action):
     """Default application launcher
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1271,6 +1271,35 @@ def update_current_task(task=None, asset=None, app=None):
     return changes
 
 
+def _format_work_template(template, session=None):
+    """Return a formatted configuration template with a Session.
+    Note: This *cannot* format the templates for published files since the
+        session does not hold the context for a published file. Instead use
+        `get_representation_path` to parse the full path to a published file.
+    Args:
+        template (str): The template to format.
+        session (dict, Optional): The Session to use. If not provided use the
+            currently active global Session.
+    Returns:
+        str: The fully formatted path.
+    """
+    if session is None:
+        session = Session
+
+    return template.format(**{
+        "root": registered_root(),
+        "project": session["AVALON_PROJECT"],
+        "asset": session["AVALON_ASSET"],
+        "task": session["AVALON_TASK"],
+        "app": session["AVALON_APP"],
+
+        # Optional
+        "silo": session.get("AVALON_SILO"),
+        "user": session.get("AVALON_USER", getpass.getuser()),
+        "hierarchy": session.get("AVALON_HIERARCHY"),
+    })
+
+
 def _make_backwards_compatible_loader(Loader):
     """Convert a old-style Loaders with `process` method to new-style Loader
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -421,27 +421,6 @@ class Application(Action):
 
         return env
 
-    def find_tools(self, entity):
-        tools = []
-        if ('data' in entity and 'tools_env' in entity['data'] and
-        len(entity['data']['tools_env']) > 0):
-            tools = entity['data']['tools_env']
-
-        elif ('data' in entity and 'visualParent' in entity['data'] and
-        entity['data']['visualParent'] is not None):
-            tmp = io.find_one({
-                "_id": entity['data']['visualParent']
-            })
-            tools = self.find_tools(tmp)
-
-        project = io.find_one({"_id": entity['parent']})
-
-        if ('data' in project and 'tools_env' in project['data'] and
-        len(project['data']['tools_env']) > 0):
-            tools = project['data']['tools_env']
-
-        return tools
-
     def initialize(self, environment):
         """Initialize work directory"""
         # Create working directory
@@ -481,17 +460,8 @@ class Application(Action):
                 self.log.error(" - %s -> %s" % (src, dst))
 
     def launch(self, environment):
-        executable_path = self.config["executable"]
-        pype_config_path = os.environ.get("PYPE_CONFIG")
-        if pype_config_path:
-            # Get platform folder name
-            os_plat = platform.system().lower()
-            # Path to folder with launchers
-            path = os.path.join(pype_config_path, "launchers", os_plat)
-            if os.path.exists(path):
-                executable_path = os.path.join(path, executable_path)
-        executable = lib.which(executable_path)
 
+        executable = lib.which(self.config["executable"])
         if executable is None:
             raise ValueError(
                 "'%s' not found on your PATH\n%s"

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -33,7 +33,7 @@ from . import (
 )
 
 from .vendor import six, acre
-from pypeapp import Anatomy
+from pype.api import Anatomy
 
 self = sys.modules[__name__]
 self._is_installed = False

--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -15,8 +15,6 @@ from ..loader.widgets import (
 from ..widgets import AssetWidget
 from ..models import AssetModel
 
-from pypeapp import config
-
 module = sys.modules[__name__]
 module.window = None
 

--- a/avalon/tools/libraryloader/lib.py
+++ b/avalon/tools/libraryloader/lib.py
@@ -1,7 +1,7 @@
 import os
 import importlib
 import logging
-from pypeapp import Roots
+from pype.api import Anatomy
 
 log = logging.getLogger(__name__)
 
@@ -28,6 +28,6 @@ class RegisteredRoots:
     @classmethod
     def registered_root(cls, project_name):
         if project_name not in cls.roots_per_project:
-            cls.roots_per_project[project_name] = Roots(project_name).roots
+            cls.roots_per_project[project_name] = Anatomy(project_name).roots
 
         return cls.roots_per_project[project_name]

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -17,7 +17,7 @@ from ..delegates import PrettyTimeDelegate
 from .model import FilesModel
 from .view import FilesView
 
-from pypeapp import Anatomy
+from pype.api import Anatomy
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Pype config logic has been moved to settings and resolved in pre-hooks, so we no longer need this dependency in avalon