### PR TITLE
Fix variable in loader exception catch

### DIFF
--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -522,7 +522,7 @@ class SubsetWidget(QtWidgets.QWidget):
                 error_info.append((
                     "Incompatible Loader",
                     None,
-                    representation["name"],
+                    representation_name,
                     item["subset"],
                     item["version_document"]["name"]
                 ))
@@ -535,7 +535,7 @@ class SubsetWidget(QtWidgets.QWidget):
                 error_info.append((
                     str(exc),
                     formatted_traceback,
-                    representation["name"],
+                    representation_name,
                     item["subset"],
                     item["version_document"]["name"]
                 ))


### PR DESCRIPTION
## Issue
- Loader may crash on `load` exception catch because is using variable `representation` which may be None at the time.

## Changes
- Instead of using `representation["name"]` is used variable `representation_name` which is always filled at the time