### PR TITLE
Remove AVALON_HIERARCHY

### DIFF
--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -88,14 +88,7 @@ SESSION_CONTEXT_KEYS = (
     # Path to working directory
     "AVALON_WORKDIR",
     # Optional path to scenes directory (see Work Files API)
-    "AVALON_SCENEDIR",
-    # Optional hierarchy for the current Asset. This can be referenced
-    # as `{hierarchy}` in your file templates.
-    # This will be (re-)computed when you switch the context to another
-    # asset. It is computed by checking asset['data']['parents'] and
-    # joining those together with `os.path.sep`.
-    # E.g.: ['ep101', 'scn0010'] -> 'ep101/scn0010'.
-    "AVALON_HIERARCHY"
+    "AVALON_SCENEDIR"
 )
 
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1140,15 +1140,20 @@ def template_data_from_session(session):
         session = Session
 
     project_name = session["AVALON_PROJECT"]
-    project = io._database[project_name].find_one(
+    project_doc = io._database[project_name].find_one(
         {"type": "project"}
     )
+    asset_doc = io._database[project_name].find_one(
+        {"type": "asset", "name": session["AVALON_ASSET"]}
+    )
+    asset_parents = asset_doc["data"].get("parents") or []
+    hierarchy = "/".join(asset_parents)
 
     return {
         "root": registered_root(),
         "project": {
-            "name": project.get("name", session["AVALON_PROJECT"]),
-            "code": project["data"].get("code", ""),
+            "name": project_doc.get("name", project_name),
+            "code": project_doc["data"].get("code") or "",
         },
         "asset": session["AVALON_ASSET"],
         "task": session["AVALON_TASK"],
@@ -1157,7 +1162,7 @@ def template_data_from_session(session):
         # Optional
         "silo": session.get("AVALON_SILO"),
         "user": session.get("AVALON_USER", getpass.getuser()),
-        "hierarchy": session.get("AVALON_HIERARCHY"),
+        "hierarchy": hierarchy
     }
 
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1291,18 +1291,9 @@ def _format_work_template(template, session=None):
     if session is None:
         session = Session
 
-    return template.format(**{
-        "root": registered_root(),
-        "project": session["AVALON_PROJECT"],
-        "asset": session["AVALON_ASSET"],
-        "task": session["AVALON_TASK"],
-        "app": session["AVALON_APP"],
+    fill_data = template_data_from_session(session)
 
-        # Optional
-        "silo": session.get("AVALON_SILO"),
-        "user": session.get("AVALON_USER", getpass.getuser()),
-        "hierarchy": session.get("AVALON_HIERARCHY"),
-    })
+    return template.format(**fill_data)
 
 
 def _make_backwards_compatible_loader(Loader):

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1144,7 +1144,13 @@ def template_data_from_session(session):
         {"type": "project"}
     )
     asset_doc = io._database[project_name].find_one(
-        {"type": "asset", "name": session["AVALON_ASSET"]}
+        {
+            "type": "asset",
+            "name": session["AVALON_ASSET"]
+        },
+        {
+            "data.parents": True
+        }
     )
     asset_parents = asset_doc["data"].get("parents") or []
     hierarchy = "/".join(asset_parents)

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1223,13 +1223,6 @@ def compute_session_changes(session, task=None, asset=None, app=None):
         # Update silo
         changes["AVALON_SILO"] = asset_document.get("silo") or ""
 
-        # Update hierarchy
-        parents = asset_document['data'].get('parents', [])
-        hierarchy = ""
-        if len(parents) > 0:
-            hierarchy = os.path.sep.join(parents)
-        changes['AVALON_HIERARCHY'] = hierarchy
-
     # Compute work directory (with the temporary changed session so far)
     project = io.find_one({"type": "project"})
     _session = session.copy()


### PR DESCRIPTION
## Description
PR does not remove hierarchy concept just skip handling of `AVALON_HIERARCHY` key in environments and `Session`.

## Changes
- removed `AVALON_HIERARCHY` from session keys
- where `AVALON_HIERARCHY` was set (on context change) is not anymore
- usage of `AVALON_HIERARCHY` was replaced with querying asset document and compute the hierarchy from `data.parents` value
    - this is how it was done on context change so it is not backwards compatible breaking just removed dependency of one key
- in `_format_work_template` function is used `template_data_from_session` to get fill data so there is only one place where these data are collected