### PR TITLE
Explicit library loader refresh

### DIFF
--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -216,7 +216,7 @@ class Window(QtWidgets.QDialog):
         self.family_config_cache.refresh()
         self.groups_config.refresh()
 
-        self._refresh()
+        self._refresh_assets()
         self._assetschanged()
 
         project_name = self.dbcon.active_project() or "No project selected"
@@ -285,6 +285,7 @@ class Window(QtWidgets.QDialog):
     # ------------------------------
 
     def _refresh(self):
+    def _refresh_assets(self):
         """Load assets from database"""
         if self.current_project is None:
             return
@@ -474,7 +475,7 @@ class Window(QtWidgets.QDialog):
             # displaying the silo tabs. Calling `window.refresh()` and directly
             # `window.set_context()` the `set_context()` seems to override the
             # scheduled refresh and the silo tabs are not shown.
-            self._refresh()
+            self._refresh_assets()
 
         asset_widget = self.data["widgets"]["assets"]
         asset_widget.select_assets(asset)

--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -154,13 +154,6 @@ class Window(QtWidgets.QDialog):
         if selection_model.selectedIndexes():
             selection_model.clearSelection()
 
-    def on_refresh_clicked(self):
-        assets_widget = self.data["widgets"]["assets"]
-        with tools_lib.preserve_states(
-            assets_widget.view, column=0, role=assets_widget.model.ObjectIdRole
-        ):
-            self._set_projects()
-
     def _set_projects(self, default=False):
         projects = self.get_filtered_projects()
 

--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -145,9 +145,6 @@ class Window(QtWidgets.QDialog):
         # Set default thumbnail on start
         thumbnail.set_thumbnail(None)
 
-        # Try set default project
-        self._set_projects(True)
-
         # Defaults
         self.resize(1330, 700)
 

--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -283,8 +283,10 @@ class Window(QtWidgets.QDialog):
         )
 
     # ------------------------------
-
     def _refresh(self):
+        project_name = self.combo_projects.currentText()
+        self._set_projects(bool(not project_name))
+
     def _refresh_assets(self):
         """Load assets from database"""
         if self.current_project is None:

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -78,7 +78,6 @@ class AssetWidget(QtWidgets.QWidget):
         selection.currentChanged.connect(self.current_changed)
         refresh.clicked.connect(self.refresh)
 
-        self.refreshButton = refresh
         self.model = model
         self.proxy = proxy
         self.view = view

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -94,8 +94,6 @@ class AssetWidget(QtWidgets.QWidget):
             loading=True,
             empty=True
         )
-        # Refresh model
-        self.model.refresh()
 
         def on_refreshed(has_item):
             self.set_loading_state(loading=False, empty=not has_item)
@@ -104,8 +102,12 @@ class AssetWidget(QtWidgets.QWidget):
             self.refreshed.emit()
             print("Duration: %.3fs" % (time.time() - time_start))
 
+        # Connect to signal
         self.model.refreshed.connect(on_refreshed)
+        # Trigger signal before refresh is called
         self.refresh_triggered.emit()
+        # Refresh model
+        self.model.refresh()
 
     def refresh(self):
         self._refresh_model()

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -90,10 +90,11 @@ class AssetWidget(QtWidgets.QWidget):
         self._store_model_selection()
         time_start = time.time()
 
-        self.set_loading_state(
-            loading=True,
-            empty=True
-        )
+        if self.dbcon.Session["AVALON_PROJECT"]:
+            self.set_loading_state(
+                loading=True,
+                empty=True
+            )
 
         def on_refreshed(has_item):
             self.set_loading_state(loading=False, empty=not has_item)


### PR DESCRIPTION
## Issue
- Library Loader is refreshed on initialization which slows down tray initialization

## Changes
- Library loader is not refreshed on initialization but refresh must be called
- removed unused metho `on_refresh_clicked`
- refresh button is not stored to `refreshButton` in asset widget as is not used in code

|:black_flag:|Pype 3.x PR|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/263|