### PR TITLE
TVPaint store metadata by chunks

### DIFF
--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -245,7 +245,16 @@ def get_workfile_metadata(metadata_key, default=None):
 
     json_string = get_workfile_metadata_string(metadata_key)
     if json_string:
-        return json.loads(json_string)
+        try:
+            return json.loads(json_string)
+        except json.decoder.JSONDecodeError:
+            # TODO remove when backwards compatibility of storing metadata
+            # will be removed
+            print((
+                "Fixed invalid metadata in workfile."
+                " Not serializable string was: {}"
+            ).format(json_string))
+            write_workfile_metadata(metadata_key, default)
     return default
 
 

--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -244,10 +244,24 @@ def write_workfile_metadata(metadata_key, value):
         .replace("'", "{__sq__}")
         .replace("\"", "{__dq__}")
     )
+    chunks = split_metadata_string(value)
+    chunks_len = len(chunks)
 
-    george_script = (
-        "tv_writeprojectstring \"{}\" \"{}\" \"{}\""
-    ).format(METADATA_SECTION, metadata_key, value)
+    write_template = "tv_writeprojectstring \"{}\" \"{}\" \"{}\""
+    george_script_parts = []
+    # Add information about chunks length to metadata key itself
+    george_script_parts.append(
+        write_template.format(METADATA_SECTION, metadata_key, chunks_len)
+    )
+    # Add chunk values to indexed metadata keys
+    for idx, chunk_value in enumerate(chunks):
+        sub_key = "{}{}".format(metadata_key, idx)
+        george_script_parts.append(
+            write_template.format(METADATA_SECTION, sub_key, chunk_value)
+        )
+
+    george_script = "\n".join(george_script_parts)
+
     return lib.execute_george_through_file(george_script)
 
 

--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -213,20 +213,20 @@ def get_workfile_metadata_string(metadata_key):
     #   indexes but the value itself
     # NOTE We don't have to care about negative values with `isdecimal` check
     if not stripped_result.isdecimal():
-        json_string = result
+        metadata_string = result
     else:
         keys = []
         for idx in range(int(stripped_result)):
             keys.append("{}{}".format(metadata_key, idx))
-        json_string = get_workfile_metadata_string_for_keys(keys)
+        metadata_string = get_workfile_metadata_string_for_keys(keys)
 
     # Replace quotes plaholders with their values
-    json_string = (
-        json_string
+    metadata_string = (
+        metadata_string
         .replace("{__sq__}", "'")
         .replace("{__dq__}", "\"")
     )
-    return json_string
+    return metadata_string
 
 
 def get_workfile_metadata(metadata_key, default=None):

--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -15,6 +15,7 @@ METADATA_SECTION = "avalon"
 SECTION_NAME_CONTEXT = "context"
 SECTION_NAME_INSTANCES = "instances"
 SECTION_NAME_CONTAINERS = "containers"
+TVPAINT_CHUNK_LENGTH = 500
 
 
 def install():
@@ -88,6 +89,34 @@ def maintained_selection():
         yield
     finally:
         pass
+
+
+def split_metadata_string(text, chunk_length=None):
+    """Split string by length.
+
+    Split text to chunks by entered length.
+    Example:
+        ```python
+        text = "ABCDEFGHIJKLM"
+        result = split_metadata_string(text, 3)
+        print(result)
+        >>> ['ABC', 'DEF', 'GHI', 'JKL']
+        ```
+
+    Args:
+        text (str): Text that will be split into chunks.
+        chunk_length (int): Single chunk size. Default chunk_length is
+            set to global variable `TVPAINT_CHUNK_LENGTH`.
+
+    Returns:
+        list: List of strings wil at least one item.
+    """
+    if chunk_length is None:
+        chunk_length = TVPAINT_CHUNK_LENGTH
+    chunks = []
+    for idx in range(chunk_length, len(text) + chunk_length, chunk_length):
+        chunks.append(text[idx-chunk_length:idx])
+    return chunks
 
 
 def get_workfile_metadata_string(metadata_key):

--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -123,12 +123,14 @@ def get_workfile_metadata_string_for_keys(metadata_keys):
     """Read metadata for specific keys from current project workfile.
 
     All values from entered keys are stored to single string without separator.
+
     Function is designed to help get all values for one metadata key at once.
+    So order of passed keys matteres.
 
     Args:
-        metadata_keys (list): Metadata keys for which data should be retrieved.
-            It is possible to enter only string (`"Instances"`).
-            Example: `["Instances0", "Instances1", "Instances2"]`
+        metadata_keys (list, str): Metadata keys for which data should be
+            retrieved. Order of keys matters! It is possible to enter only
+            single key as string.
     """
     # Add ability to pass only single key
     if isinstance(metadata_keys, str):
@@ -170,13 +172,32 @@ def get_workfile_metadata_string_for_keys(metadata_keys):
     os.remove(output_filepath)
 
     return output_string
+
+
+def get_workfile_metadata_string(metadata_key):
+    """Read metadata for specific key from current project workfile."""
+    result = get_workfile_metadata_string_for_keys([metadata_key])
+    if not result:
+        return result
+
+    stripped_result = result.strip()
+    # NOTE Backwards compatibility when metadata key did not store range of key
+    #   indexes but the value itself
+    # NOTE We don't have to care about negative values with `isdecimal` check
+    if not stripped_result.isdecimal():
+        json_string = result
+    else:
+        keys = []
+        for idx in range(int(stripped_result)):
+            keys.append("{}{}".format(metadata_key, idx))
+        json_string = get_workfile_metadata_string_for_keys(keys)
+
     # Replace quotes plaholders with their values
     json_string = (
         json_string
         .replace("{__sq__}", "'")
         .replace("{__dq__}", "\"")
     )
-    os.remove(output_filepath)
     return json_string
 
 

--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -15,7 +15,31 @@ METADATA_SECTION = "avalon"
 SECTION_NAME_CONTEXT = "context"
 SECTION_NAME_INSTANCES = "instances"
 SECTION_NAME_CONTAINERS = "containers"
+# Maximum length of metadata chunk string
+# TODO find out the max (500 is safe enough)
 TVPAINT_CHUNK_LENGTH = 500
+
+"""TVPaint's Metadata
+
+Metadata are stored to TVPaint's workfile.
+
+Workfile works similar to .ini file but has few limitation. Most important
+limitation is that value under key has limited length. Due to this limitation
+each metadata section/key stores number of "subkeys" that are related to
+the section.
+
+Example:
+Metadata key `"instances"` may have stored value "2". In that case it is
+expected that there are also keys `["instances0", "instances1"]`.
+
+Workfile data looks like:
+```
+[avalon]
+instances0=[{{__dq__}id{__dq__}: {__dq__}pyblish.avalon.instance{__dq__...
+instances1=...more data...
+instances=2
+```
+"""
 
 
 def install():
@@ -178,9 +202,12 @@ def get_workfile_metadata_string(metadata_key):
     """Read metadata for specific key from current project workfile."""
     result = get_workfile_metadata_string_for_keys([metadata_key])
     if not result:
-        return result
+        return None
 
     stripped_result = result.strip()
+    if not stripped_result:
+        return None
+
     # NOTE Backwards compatibility when metadata key did not store range of key
     #   indexes but the value itself
     # NOTE We don't have to care about negative values with `isdecimal` check

--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -139,7 +139,8 @@ def split_metadata_string(text, chunk_length=None):
         chunk_length = TVPAINT_CHUNK_LENGTH
     chunks = []
     for idx in range(chunk_length, len(text) + chunk_length, chunk_length):
-        chunks.append(text[idx-chunk_length:idx])
+        start_idx = idx - chunk_length
+        chunks.append(text[start_idx:idx])
     return chunks
 
 


### PR DESCRIPTION
## Issue
Seems like TVPaint's workfile metadata have strictly limited metadata string length limitation in specific versions of TVPaint. This cause that stored metadata are lost.

## Suggested solution
Store metadata value by string chunks. With this is possible to add unlimited length of metadata string (in theory).
**Current data in workfile:**
```
[avalon]
instances=[{..data string..}]
```

**New way of storing data:**
```
[avalon]
# says how many indexes of the key hold data.
instances=3
# index 0 - containing start of string
instances0=[{...start of data string...
# index 1 - middle text
instances1=...some more data...
# index 2 - contain end of string
instances2=...end of data string}]
```

This ways was kept backwards compatibility of loading metadata values as it is just check if value contain only numbers.

Added auto-fix of invalid metadata values. They are not usable anyway.

### Disadvantages
- loading of metadata is a little bit slower as it has to ask TVPaint twice for data.

### Nice to have TODOs
- find out max length of metadata string (now is set to `500` but I didn't try higher)
- remove unused keys
    - if index was changed e.g. on `"instances" from `3` to `2` then value of `"instances2"` stays unchanged in workfile but is never used.