### PR TITLE
TVPaint load workfile path with spaces

### DIFF
--- a/avalon/tvpaint/workio.py
+++ b/avalon/tvpaint/workio.py
@@ -8,13 +8,16 @@
 
 from avalon import api
 from . import CommunicationWrapper
+from .lib import execute_george_through_file
 from . pipeline import save_current_workfile_context
 
 
 def open_file(filepath):
     """Open the scene file in Blender."""
-    george_script = "tv_LoadProject {}".format(filepath.replace("\\", "/"))
-    return CommunicationWrapper.execute_george(george_script)
+    george_script = "tv_LoadProject '\"'\"{}\"'\"'".format(
+        filepath.replace("\\", "/")
+    )
+    return execute_george_through_file(george_script)
 
 
 def save_file(filepath):


### PR DESCRIPTION
## Issue
Same issue as PR in pype https://github.com/pypeclub/pype/pull/886 did. Used path with spaces must be wrapped with quotes and double quotes. Strange is that save of workfile do not require this wrapping.

## Changes
Path to workfile is wrapped in format `'"'"{}"'"'` so workfiles with spaces in paths can be opened.