### PR TITLE
TVPaint without layer ids

### DIFF
--- a/avalon/tvpaint/pipeline.py
+++ b/avalon/tvpaint/pipeline.py
@@ -69,15 +69,15 @@ def uninstall():
 
 
 def containerise(
-    name, namespace, layer_ids, context, loader, current_containers=None
+    name, namespace, members, context, loader, current_containers=None
 ):
     """Add new container to metadata.
 
     Args:
         name (str): Container name.
         namespace (str): Container namespace.
-        layer_ids (list): List of layer that were loaded and belongs to the
-            container.
+        members (list): List of members that were loaded and belongs
+            to the container (layer names).
         current_containers (list): Preloaded containers. Should be used only
             on update/switch when containers were modified durring the process.
 
@@ -88,7 +88,7 @@ def containerise(
     container_data = {
         "schema": "avalon-core:container-2.0",
         "id": AVALON_CONTAINER_ID,
-        "members": layer_ids,
+        "members": members,
         "name": name,
         "namespace": namespace,
         "loader": str(loader),
@@ -395,7 +395,7 @@ class Loader(api.Loader):
     hosts = ["tvpaint"]
 
     @staticmethod
-    def layer_ids_from_container(container):
+    def get_members_from_container(container):
         if "members" not in container and "objectName" in container:
             # Backwards compatibility
             layer_ids_str = container.get("objectName")


### PR DESCRIPTION
## Changes
- apply changes to use layer names instead of layer ids in tvpaint implementation
- added changes from PR https://github.com/pypeclub/avalon-core/pull/259

|:black_flag:|Pype 2.x PR|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/261|

|:black_flag:|this PR depends on|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/904|