### PR TITLE
Master versions fix

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 from . import (
     io,
     lib,
+    schema,
 
     Session,
 
@@ -1870,10 +1871,11 @@ def is_compatible_loader(Loader, context):
         bool
 
     """
-    if context["subset"]["schema"] == "avalon-core:subset-3.0":
-        families = context["subset"]["data"]["families"]
-    else:
+    maj_version, _ = schema.get_schema_version(context["subset"]["schema"])
+    if maj_version < 3:
         families = context["version"]["data"].get("families", [])
+    else:
+        families = context["subset"]["data"]["families"]
 
     representation = context["representation"]
     has_family = ("*" in Loader.families or

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1210,14 +1210,36 @@ def get_repres_contexts(representation_ids, dbcon=None):
         repre_docs_by_id[repre_doc["_id"]] = repre_doc
 
     version_docs = dbcon.find({
-        "type": "version",
+        "type": {"$in": ["version", "master_version"]},
         "_id": {"$in": list(version_ids)}
     })
+
     version_docs_by_id = {}
+    master_version_docs = []
+    versions_for_masters = set()
     subset_ids = set()
     for version_doc in version_docs:
+        if version_doc["type"] == "master_version":
+            master_version_docs.append(version_doc)
+            versions_for_masters.add(version_doc["version_id"])
         version_docs_by_id[version_doc["_id"]] = version_doc
         subset_ids.add(version_doc["parent"])
+
+    if versions_for_masters:
+        _version_docs = dbcon.find({
+            "type": "version",
+            "_id": {"$in": list(versions_for_masters)}
+        })
+        _version_data_by_id = {
+            version_doc["_id"]: version_doc["data"]
+            for version_doc in _version_docs
+        }
+
+        for master_version_doc in master_version_docs:
+            master_version_id = master_version_doc["_id"]
+            version_id = master_version_doc["version_id"]
+            version_data = copy.deepcopy(_version_data_by_id[version_id])
+            version_docs_by_id[master_version_id]["data"] = version_data
 
     subset_docs = dbcon.find({
         "type": "subset",

--- a/avalon/schema.py
+++ b/avalon/schema.py
@@ -14,6 +14,7 @@ Resources:
 
 import os
 import sys
+import re
 import json
 import logging
 
@@ -23,6 +24,33 @@ log_ = logging.getLogger(__name__)
 
 ValidationError = jsonschema.ValidationError
 SchemaError = jsonschema.SchemaError
+
+
+def get_schema_version(schema_name):
+    """Extract version form schema name.
+
+    It is expected that schema name contain only major and minor version.
+
+    Expected name should match to:
+    "{name}:{type}-{major version}.{minor version}"
+    - `name` - must not contain colon
+    - `type` - must not contain dash
+    - major and minor versions must be numbers separated by dot
+
+    Args:
+    schema_name(str): Name of schema that should be parsed.
+
+    Returns:
+    tuple: Contain two values major version as first and minor version as
+    second. When schema does not match parsing regex then `(0, 0)` is
+    returned.
+    """
+    schema_regex = re.compile(r"[^:]+:[^-]+-(\d.\d)")
+    groups = schema_regex.findall(schema_name)
+    if not groups:
+    return 0, 0
+
+    return groups[0].split(".")
 
 
 def validate(data, schema=None):

--- a/avalon/schema.py
+++ b/avalon/schema.py
@@ -48,7 +48,7 @@ def get_schema_version(schema_name):
     schema_regex = re.compile(r"[^:]+:[^-]+-(\d.\d)")
     groups = schema_regex.findall(schema_name)
     if not groups:
-    return 0, 0
+        return 0, 0
 
     return groups[0].split(".")
 

--- a/avalon/tools/delegates.py
+++ b/avalon/tools/delegates.py
@@ -123,7 +123,8 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
                 "parent": parent_id
             }, {
                 "name": 1,
-                "data.tags": 1
+                "data.tags": 1,
+                "version_id": 1
             }
         )
 

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -1,6 +1,9 @@
 import copy
 
-from ... import style
+from ... import (
+    style,
+    schema
+)
 from ...vendor.Qt import QtCore, QtGui
 from ...vendor import qtawesome
 
@@ -230,10 +233,11 @@ class SubsetsModel(TreeModel):
             frames = None
             duration = None
 
-        if item["schema"] == "avalon-core:subset-3.0":
-            families = item["data"]["families"]
-        else:
+        schema_maj_version, _ = schema.get_schema_version(item["schema"])
+        if schema_maj_version < 3:
             families = version_data.get("families", [None])
+        else:
+            families = item["data"]["families"]
 
         family = families[0]
         family_config = self.family_config_cache.family_config(family)

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -166,7 +166,7 @@ class View(QtWidgets.QTreeView):
                         version_id_by_repre_id.items()
                     ):
                         if _version_id == master_version_id:
-                            version_id_by_repre_id[_repre_id] = version_id
+                            version_id_by_repre_id[_repre_id] = _version_id
 
                 version_docs = io.find(
                     {


### PR DESCRIPTION
## Description
There were found out several issues with master version implementation.
1.) Master version documents queried from mongo didn't have enough data to be painted properly in subset view (loader).
2.) Master versions were not handled in `get_repres_contexts`.
3.) Action in scene inventory `Switch to versioned` don't work because of bad variable usage
4.) During fixing of issue 1.) was discovered that the issue is happening because the schema check on subset is not 100% in pype's modifications.

## Changes
- version delegate have access to all required data for master versions
- `get_repres_contexts` collect required data for master versions
- fixed `Switch to versioned` action in Scene inventory tool
- schema check was modified to care only about version of the schema not for whole string
   - implemented `get_schema_version` in `avalon/schema.py` which returns tuple of integers representing version from schema name
   - this function is used at two places where subset schema name are checked to define where from families are used