### PR TITLE
Harmony deadline submission

### DIFF
--- a/avalon/harmony/lib.py
+++ b/avalon/harmony/lib.py
@@ -274,10 +274,6 @@ def show(module_name):
     else:
         module.show()
 
-    # QApplication needs to always execute.
-    if "publish" in module_name:
-        return
-
     app.exec_()
 
 


### PR DESCRIPTION
Removed unneeded workaround. Pyblish is not running exec_ anymore.

Requires:
pypeclub/pype#911