### PR TITLE
Fix schema version extraction

### DIFF
--- a/avalon/schema.py
+++ b/avalon/schema.py
@@ -50,7 +50,8 @@ def get_schema_version(schema_name):
     if not groups:
         return 0, 0
 
-    return groups[0].split(".")
+    maj_version, min_version = groups[0].split(".")
+    return int(maj_version), int(min_version)
 
 
 def validate(data, schema=None):


### PR DESCRIPTION
## Changes
- `get_schema_version` return integeres, not strings

|:black_flag:|Pype 2.x PR|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/268|