### PR TITLE
Set current asset in switcher with button

### DIFF
--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -729,11 +729,8 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         self._subset_label = QtWidgets.QLabel("")
         self._repre_label = QtWidgets.QLabel("")
 
-        main_layout = QtWidgets.QVBoxLayout()
-        context_layout = QtWidgets.QHBoxLayout()
-        asset_layout = QtWidgets.QVBoxLayout()
-        subset_layout = QtWidgets.QVBoxLayout()
-        repre_layout = QtWidgets.QVBoxLayout()
+
+        main_layout = QtWidgets.QGridLayout(self)
 
         accept_icon = qtawesome.icon("fa.check", color="white")
         accept_btn = QtWidgets.QPushButton()
@@ -741,17 +738,17 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         accept_btn.setFixedWidth(24)
         accept_btn.setFixedHeight(24)
 
-        asset_layout.addWidget(self._assets_box)
-        asset_layout.addWidget(self._asset_label)
-        subset_layout.addWidget(self._subsets_box)
-        subset_layout.addWidget(self._subset_label)
-        repre_layout.addWidget(self._representations_box)
-        repre_layout.addWidget(self._repre_label)
-
-        context_layout.addLayout(asset_layout)
-        context_layout.addLayout(subset_layout)
-        context_layout.addLayout(repre_layout)
-        context_layout.addWidget(accept_btn)
+        # Asset column
+        main_layout.addWidget(self._assets_box, 1, 0)
+        main_layout.addWidget(self._asset_label, 2, 0)
+        # Subset column
+        main_layout.addWidget(self._subsets_box, 1, 1)
+        main_layout.addWidget(self._subset_label, 2, 1)
+        # Representation column
+        main_layout.addWidget(self._representations_box, 1, 2)
+        main_layout.addWidget(self._repre_label, 2, 2)
+        # Btn column
+        main_layout.addWidget(accept_btn, 1, 3)
 
         self._accept_btn = accept_btn
 
@@ -765,9 +762,6 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             self._combobox_value_changed
         )
         self._accept_btn.clicked.connect(self._on_accept)
-
-        main_layout.addLayout(context_layout)
-        self.setLayout(main_layout)
 
         self._items = items
         self._prepare_content_data()

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -729,6 +729,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         self._subset_label = QtWidgets.QLabel("")
         self._repre_label = QtWidgets.QLabel("")
 
+        self.current_asset_btn = QtWidgets.QPushButton("Use current asset")
 
         main_layout = QtWidgets.QGridLayout(self)
 
@@ -739,6 +740,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         accept_btn.setFixedHeight(24)
 
         # Asset column
+        main_layout.addWidget(self.current_asset_btn, 0, 0)
         main_layout.addWidget(self._assets_box, 1, 0)
         main_layout.addWidget(self._asset_label, 2, 0)
         # Subset column
@@ -762,6 +764,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             self._combobox_value_changed
         )
         self._accept_btn.clicked.connect(self._on_accept)
+        self.current_asset_btn.clicked.connect(self._on_current_asset)
 
         self._items = items
         self._prepare_content_data()
@@ -1486,6 +1489,16 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             if repre_doc["name"] not in repre_names:
                 validation_state.repre_ok = False
                 break
+
+    def _on_current_asset(self):
+        # Set initial asset as current.
+        asset_name = api.Session["AVALON_ASSET"]
+        index = self._assets_box.findText(
+            asset_name, QtCore.Qt.MatchFixedString
+        )
+        if index >= 0:
+            print("Setting asset to {}".format(asset_name))
+            self._assets_box.setCurrentIndex(index)
 
     def _on_accept(self):
         # Use None when not a valid value or when placeholder value


### PR DESCRIPTION
## Description
- sometimes it is necessary to quickly set asset in switch dialog to current context asset (Based on PR https://github.com/pypeclub/avalon-core/pull/215)

## Changes
- added button which set current context asset in asset box on click

## Screenshot
![image](https://user-images.githubusercontent.com/43494761/105825080-774f2580-5fbf-11eb-9ee5-9f01b6077fe2.png)

|:black_flag:|Pype 2.x PR|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/270|