### PR TITLE
Photoshop safer loading workfile

### DIFF
--- a/avalon/photoshop/lib.py
+++ b/avalon/photoshop/lib.py
@@ -93,13 +93,15 @@ def launch(application, workfile):
     from avalon import api, photoshop
 
     # check if workfile available and add it to executable
+
+    args = [application]
     if workfile:
-        application = " ".join([application, workfile])
+        args.append(workfile)
 
     api.install(photoshop)
     sys.excepthook = safe_excepthook
     # Launch Photoshop and the websocket server.
-    process = subprocess.Popen(application, stdout=subprocess.PIPE)
+    process = subprocess.Popen(args, stdout=subprocess.PIPE)
 
     websocket_server = WebSocketServer()
     websocket_server.websocket_thread.start()


### PR DESCRIPTION
Safer way to launching PS with workfile. Without this some characters in workfile path could be consumed. This handles escaping better.

|:black_flag: |Pype 2.x PR|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/274