### PR TITLE
Fix missing families on subset

### DIFF
--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -239,7 +239,10 @@ class SubsetsModel(TreeModel):
         else:
             families = item["data"]["families"]
 
-        family = families[0]
+        family = None
+        if families:
+            family = families[0]
+
         family_config = self.family_config_cache.family_config(family)
 
         item.update({


### PR DESCRIPTION
## Issue
- integrated subset document may not have filled `families` keys

## Changes
- used `None` family if families are empty

|:black_flag: |Pype 2.x PR|
|---|---|
|pype|https://github.com/pypeclub/avalon-core/pull/277|