### PR TITLE
Use families from both subset and version for loader filtering

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1729,7 +1729,10 @@ def is_compatible_loader(Loader, context):
     if maj_version < 3:
         families = context["version"]["data"].get("families", [])
     else:
-        families = context["subset"]["data"]["families"]
+        # PYPE specific Backwards compatibility
+        families = set(context["subset"]["data"].get("families") or [])
+        for _family in context["version"]["data"].get("families", []):
+            families.add(_family)
 
     representation = context["representation"]
     has_family = ("*" in Loader.families or

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -517,15 +517,19 @@ class SubsetsModel(TreeModel):
                 subset_counter += 1
 
             for subset_doc in subset_docs:
+                last_version = last_versions_by_subset_id.get(
+                    subset_doc["_id"]
+                )
+                # Skip subsets without version
+                if not last_version:
+                    continue
+
                 asset_id = subset_doc["parent"]
 
                 data = copy.deepcopy(subset_doc)
                 data["subset"] = subset_name
                 data["asset"] = asset_docs_by_id[asset_id]["name"]
 
-                last_version = last_versions_by_subset_id.get(
-                    subset_doc["_id"]
-                )
                 data["last_version"] = last_version
 
                 item = Item()


### PR DESCRIPTION
## Issue
- pype didn't publish families into subset so schema version check does not work for subsets published before 2.15.0
- loader's subset model does not count on missing versions for subset

## Changes
- added Pype specific backwards compatibility into `is_compatible_loader` to use families from both subset and version
- subsets without version are not showed in loader gui