### PR TITLE
Blender: make tool windows work on linux again

### DIFF
--- a/avalon/blender/ops.py
+++ b/avalon/blender/ops.py
@@ -73,7 +73,7 @@ def _has_visible_windows(app: QtWidgets.QApplication) -> bool:
         except RuntimeError:
             continue
 
-    return False
+    return is_visible
 
 
 def _process_app_events(app: QtWidgets.QApplication) -> Optional[float]:

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1875,7 +1875,10 @@ def is_compatible_loader(Loader, context):
     if maj_version < 3:
         families = context["version"]["data"].get("families", [])
     else:
-        families = context["subset"]["data"]["families"]
+        # PYPE specific Backwards compatibility
+        families = set(context["subset"]["data"].get("families") or [])
+        for _family in context["version"]["data"].get("families", []):
+            families.add(_family)
 
     representation = context["representation"]
     has_family = ("*" in Loader.families or


### PR DESCRIPTION
## Bug description:

This is fixing bug when Avalon windows opened in Blender on Centos Linux (at least?) didn't processed events and were "frozen".