### PR TITLE
Optionally add task to subset name

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -280,6 +280,26 @@ class Creator(object):
     def get_subset_name(
         cls, user_text, task_name, asset_id, project_name, host_name=None
     ):
+        """Return subset name created with entered arguments.
+
+        Logic extracted from Creator tool. This method should give ability
+        to get subset name without the tool.
+
+        TODO: Maybe change `user_text` variable.
+
+        By default is output concatenated family with user text.
+
+        Args:
+            user_text (str): What is entered by user in creator tool.
+            task_name (str): Context's task name.
+            asset_id (ObjectId): Mongo ID of context's asset.
+            project_name (str): Context's project name.
+            host_name (str): Name of host.
+
+        Returns:
+            str: Formatted subset name with entered arguments. Should match
+                config's logic.
+        """
         # Capitalize first letter of user input
         if user_text:
             user_text = user_text[0].capitalize() + user_text[1:]

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -278,19 +278,19 @@ class Creator(object):
 
     @classmethod
     def get_subset_name(
-        cls, user_text, task_name, asset_id, project_name, host_name=None
+        cls, variant, task_name, asset_id, project_name, host_name=None
     ):
         """Return subset name created with entered arguments.
 
         Logic extracted from Creator tool. This method should give ability
         to get subset name without the tool.
 
-        TODO: Maybe change `user_text` variable.
+        TODO: Maybe change `variant` variable.
 
         By default is output concatenated family with user text.
 
         Args:
-            user_text (str): What is entered by user in creator tool.
+            variant (str): What is entered by user in creator tool.
             task_name (str): Context's task name.
             asset_id (ObjectId): Mongo ID of context's asset.
             project_name (str): Context's project name.
@@ -301,11 +301,11 @@ class Creator(object):
                 config's logic.
         """
         # Capitalize first letter of user input
-        if user_text:
-            user_text = user_text[0].capitalize() + user_text[1:]
+        if variant:
+            variant = variant[0].capitalize() + variant[1:]
 
         family = cls.family.rsplit(".", 1)[-1]
-        return "{}{}".format(family, user_text)
+        return "{}{}".format(family, variant)
 
     def process(self):
         pass

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -277,7 +277,9 @@ class Creator(object):
         self.data.update(data or {})
 
     @classmethod
-    def get_subset_name(cls, user_text, task_name, asset_id, project_name):
+    def get_subset_name(
+        cls, user_text, task_name, asset_id, project_name, host_name=None
+    ):
         # Capitalize first letter of user input
         if user_text:
             user_text = user_text[0].capitalize() + user_text[1:]

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -276,6 +276,15 @@ class Creator(object):
 
         self.data.update(data or {})
 
+    @classmethod
+    def get_subset_name(cls, user_text, task_name, asset_id, project_name):
+        # Capitalize first letter of user input
+        if user_text:
+            user_text = user_text[0].capitalize() + user_text[1:]
+
+        family = cls.family.rsplit(".", 1)[-1]
+        return "{}{}".format(family, user_text)
+
     def process(self):
         pass
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -34,7 +34,7 @@ from . import (
 )
 
 from .vendor import six
-from pype.api import Anatomy
+from pype.lib import Anatomy
 
 self = sys.modules[__name__]
 self._is_installed = False

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -23,11 +23,14 @@ PluginRole = QtCore.Qt.UserRole + 5
 
 Separator = "---separator---"
 
+# TODO regex should be defined by schema
+SubsetAllowedSymbols = "a-zA-Z0-9_."
+
 
 class SubsetNameValidator(QtGui.QRegExpValidator):
 
     invalid = QtCore.Signal(set)
-    pattern = "^[a-zA-Z0-9_.]*$"
+    pattern = "^[{}]*$".format(SubsetAllowedSymbols)
 
     def __init__(self):
         reg = QtCore.QRegExp(self.pattern)

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -301,12 +301,30 @@ class Window(QtWidgets.QDialog):
             return
 
         # Get the asset from the database which match with the name
-        asset = io.find_one({"name": asset_name, "type": "asset"},
-                            projection={"_id": 1})
+        asset_doc = io.find_one(
+            {"name": asset_name, "type": "asset"},
+            projection={"_id": 1}
+        )
         # Get plugin
         plugin = item.data(PluginRole)
+        if asset_doc and plugin:
+            project_name = io.Session["AVALON_PROJECT"]
+            asset_id = asset_doc["_id"]
+            task_name = io.Session["AVALON_TASK"]
 
-        if asset and plugin:
+            # Calculate subset name with Creator plugin
+            subset_name = plugin.get_subset_name(
+                user_input_text, task_name, asset_id, project_name
+            )
+            # Force replacement of prohibited symbols
+            # QUESTION should Creator care about this and here should be only
+            #   validated with schema regex?
+            subset_name = re.sub(
+                "[^{}]+".format(SubsetAllowedSymbols),
+                "",
+                subset_name
+            )
+            result.setText(subset_name)
 
             # Get all subsets of the current asset
 

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -121,7 +121,6 @@ class SubsetNameLineEdit(QtWidgets.QLineEdit):
 class Window(QtWidgets.QDialog):
 
     stateChanged = QtCore.Signal(bool)
-    taskSubsetFamilies = ["render"]
 
     def __init__(self, parent=None):
         super(Window, self).__init__(parent)
@@ -308,59 +307,10 @@ class Window(QtWidgets.QDialog):
         plugin = item.data(PluginRole)
 
         if asset and plugin:
-            # Get family
-            family = plugin.family.rsplit(".", 1)[-1]
-            regex = "{}*".format(family)
-            existed_subset_split = family
-
-            if family in self.taskSubsetFamilies:
-                task = io.Session.get('AVALON_TASK', '')
-                sanitized_task = re.sub('[^0-9a-zA-Z]+', '', task)
-                regex = "{}{}*".format(
-                    family,
-                    sanitized_task.capitalize()
-                )
-                existed_subset_split = "{}{}".format(
-                    family,
-                    sanitized_task.capitalize()
-                )
 
             # Get all subsets of the current asset
-            subsets = io.find(filter={"type": "subset",
-                                      "name": {"$regex": regex,
-                                               "$options": "i"},
-                                      "parent": asset["_id"]}) or []
-
-            # Get all subsets' their subset name, "Default", "High", "Low"
-            existed_subsets = [sub["name"].split(existed_subset_split)[-1]
-                               for sub in subsets]
-
-            if plugin.defaults and isinstance(plugin.defaults, list):
-                defaults = plugin.defaults[:] + [Separator]
-                lowered = [d.lower() for d in plugin.defaults]
-                for sub in [s for s in existed_subsets
-                            if s.lower() not in lowered]:
-                    defaults.append(sub)
-            else:
-                defaults = existed_subsets
 
             self._build_menu(defaults)
-
-            # Update the result
-            if subset_name:
-                subset_name = subset_name[0].upper() + subset_name[1:]
-
-            if family in self.taskSubsetFamilies:
-                result.setText("{}{}{}".format(
-                    family,
-                    sanitized_task.capitalize(),
-                    subset_name
-                ))
-            else:
-                result.setText("{}{}".format(
-                    family,
-                    subset_name
-                ))
 
             # Indicate subset existence
             if not subset_name:

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -359,7 +359,6 @@ class Window(QtWidgets.QDialog):
                     if _result:
                         subset_hints |= set(_result.groups())
 
-            subset_hints = subset_hints - set(defaults)
             if subset_hints:
                 if defaults:
                     defaults.append(Separator)

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -27,24 +27,21 @@ class TreeModel(QtCore.QAbstractItemModel):
             return self.item_class
         return Item
 
-    def rowCount(self, parent):
-        if parent.isValid():
-            item = parent.internalPointer()
+    def rowCount(self, parent=None):
+        if parent is None or not parent.isValid():
+            parent_item = self._root_item
         else:
-            item = self._root_item
-
-        return item.childCount()
+            parent_item = parent.internalPointer()
+        return parent_item.childCount()
 
     def columnCount(self, parent):
         return len(self.Columns)
 
     def data(self, index, role):
-
         if not index.isValid():
             return None
 
         if role == QtCore.Qt.DisplayRole or role == QtCore.Qt.EditRole:
-
             item = index.internalPointer()
             column = index.column()
 


### PR DESCRIPTION
## Changes
- subset template for creator api is defined by `Creator` class with class method `get_subset_name`
    - the method by default returns what was hardcoded in Creator tool
- modified how duplicated subset names are checked and already existing subset values are prepared

|:black_flag: |this depends on|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1068|

|:black_flag: |Pype 2.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1072|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/289|
|pype-config|https://github.com/pypeclub/pype-config/pull/101|