### PR TITLE
Cache plugins.

### DIFF
--- a/avalon/api.py
+++ b/avalon/api.py
@@ -57,6 +57,7 @@ from .pipeline import (
     registered_host,
     registered_config,
     registered_plugin_paths,
+    registered_plugins,
     registered_root,
 
     deregister_plugin,

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -57,8 +57,9 @@ from .pipeline import (
     registered_host,
     registered_config,
     registered_plugin_paths,
-    registered_plugins,
     registered_root,
+
+    last_discovered_plugins,
 
     deregister_plugin,
     deregister_plugin_path,

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -41,7 +41,7 @@ self._is_installed = False
 self._config = None
 self.data = {}
 # The currently registered plugins from the last `discover` call.
-self.registered_plugins = {}
+self.last_discovered_plugins = {}
 
 log = logging.getLogger(__name__)
 
@@ -777,7 +777,7 @@ def discover(superclass):
     sorted_plugins = sorted(
         plugins.values(), key=lambda Plugin: Plugin.__name__
     )
-    self.registered_plugins[superclass.__name__] = sorted_plugins
+    self.last_discovered_plugins[superclass.__name__] = sorted_plugins
     return sorted_plugins
 
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -40,6 +40,8 @@ self = sys.modules[__name__]
 self._is_installed = False
 self._config = None
 self.data = {}
+# The currently registered plugins from the last `discover` call.
+self.registered_plugins = {}
 
 log = logging.getLogger(__name__)
 
@@ -772,7 +774,11 @@ def discover(superclass):
             print("Warning: Overwriting %s" % plugin.__name__)
         plugins[plugin.__name__] = plugin
 
-    return sorted(plugins.values(), key=lambda Plugin: Plugin.__name__)
+    sorted_plugins = sorted(
+        plugins.values(), key=lambda Plugin: Plugin.__name__
+    )
+    self.registered_plugins[superclass.__name__] = sorted_plugins
+    return sorted_plugins
 
 
 def plugin_from_module(superclass, module):


### PR DESCRIPTION
**Goal**

To cache plugins for later use.

**Motivation**

There is currently no way of getting already registered plugins without running `api.discover`. When doing this inside a plugin it results in that instance of the plugin getting flushed from memory. An example of this:

```python
from avalon import api, io


class ProjectionLoader(api.Loader):
    """
    This will load camera, pointcache and image to build a projection setup.
    """

    families = ["projection"]
    representations = ["json"]

    label = "Load Projection"
    icon = "camera"
    color = "orange"
    node_color = "0x3469ffff"

    def load(self, context, name, namespace, data):
        api.discover(api.Loader)
        print(io.find_one({"_id": context["asset"]["_id"]}))
```

**Implementation**

Currently the cached plugins from the last `api.discover` call is stored under `api.registered_plugins`. This naming convention is up for discussion. @BigRoy has mentioned these alternatives; `api.cached_plugins` and `api.last_discovered_plugins`.

The data structure of the stored plugins is a dictionary with the superclass' name as key and the discovered plugins as values;
```
{'Loader': [<class 'load_camera_abc.AlembicCameraLoader'>, <class 'load_pointcache_abc.AlembicPointcacheLoader'>, <class 'copy_file.CopyFile'>, <class 'copy_file_path.CopyFilePath'>, <class 'load_script_precomp.LinkAsGroup'>, <class 'load_backdrop.LoadBackdropNodes'>, <class 'load_gizmo.LoadGizmo'>, <class 'load_gizmo_ip.LoadGizmoInputProcess'>, <class 'load_image.LoadImage'>, <class 'load_luts.LoadLuts'>, <class 'load_luts_ip.LoadLutsInputProcess'>, <class 'load_mov.LoadMov'>, <class 'load_sequence.LoadSequence'>, <class 'load_matchmove.MatchmoveLoader'>, <class 'open_djv.OpenInDJV'>, <class 'open_file.Openfile'>, <class 'load_projection.ProjectionLoader'>, <class 'actions.SetFrameRangeLoader'>, <class 'actions.SetFrameRangeWithHandlesLoader'>]}
```