### PR TITLE
workfile: swapping save-as button position with open

### DIFF
--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -406,9 +406,9 @@ class FilesWidget(QtWidgets.QWidget):
         buttons = QtWidgets.QWidget()
         layout = QtWidgets.QHBoxLayout(buttons)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(widgets["open"])
-        layout.addWidget(widgets["browse"])
         layout.addWidget(widgets["save"])
+        layout.addWidget(widgets["browse"])
+        layout.addWidget(widgets["open"])
 
         # Build files widgets for home page
         layout = QtWidgets.QVBoxLayout(self)


### PR DESCRIPTION
- this had been suggestion from client that this swap would be more intuitive UX