### PR TITLE
Pype workfiles tool in all hosts

### DIFF
--- a/avalon/aftereffects/lib.py
+++ b/avalon/aftereffects/lib.py
@@ -15,7 +15,7 @@ from wsrpc_aiohttp import (
 )
 
 from ..vendor.Qt import QtWidgets
-from ..tools import workfiles
+from pype.tools import workfiles
 from avalon.tools.webserver.app import WebServerTool
 from .ws_stub import AfterEffectsServerStub
 
@@ -60,7 +60,11 @@ def show(module_name):
         app = QtWidgets.QApplication(sys.argv)
 
     # Import and show tool.
-    tool_module = importlib.import_module("avalon.tools." + module_name)
+    if module_name == "workfiles":
+        # Use Pype's workfiles tool
+        tool_module = workfiles
+    else:
+        tool_module = importlib.import_module("avalon.tools." + module_name)
 
     if "loader" in module_name:
         tool_module.show(use_context=True)

--- a/avalon/blender/ops.py
+++ b/avalon/blender/ops.py
@@ -12,7 +12,7 @@ import bpy.utils.previews
 
 from ..tools.creator.app import Window as creator_window
 from ..tools.loader.app import Window as loader_window
-from ..tools.workfiles.app import Window as workfiles_window
+from pype.tools.workfiles.app import Window as workfiles_window
 from ..tools.sceneinventory.app import Window as sceneinventory_window
 from ..tools import publish
 

--- a/avalon/harmony/TB_sceneOpened.js
+++ b/avalon/harmony/TB_sceneOpened.js
@@ -388,7 +388,7 @@ function start() {
         app.avalonClient.send({
             'module': 'avalon.harmony.lib',
             'method': 'show',
-            'args': ['avalon.tools.workfiles']
+            'args': ['pype.tools.workfiles']
         }, false);
     };
     if (app.avalonMenu == null) {

--- a/avalon/harmony/lib.py
+++ b/avalon/harmony/lib.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 
 from .server import Server
 from ..vendor.Qt import QtWidgets
-from ..tools import workfiles
+from pype.tools import workfiles
 from ..toonboom import setup_startup_scripts, check_libs
 
 self = sys.modules[__name__]

--- a/avalon/photoshop/lib.py
+++ b/avalon/photoshop/lib.py
@@ -15,7 +15,7 @@ from wsrpc_aiohttp import (
 )
 
 from ..vendor.Qt import QtWidgets
-from ..tools import workfiles
+from pype.tools import workfiles
 
 from avalon.tools.webserver.app import WebServerTool
 from .ws_stub import PhotoshopServerStub
@@ -59,8 +59,12 @@ def show(module_name):
     if not app:
         app = QtWidgets.QApplication(sys.argv)
 
-    # Import and show tool.
-    tool_module = importlib.import_module("avalon.tools." + module_name)
+    if module_name == "workfiles":
+        # Use Pype's workfiles tool
+        tool_module = workfiles
+    else:
+        # Import and show tool.
+        tool_module = importlib.import_module("avalon.tools." + module_name)
 
     if "loader" in module_name:
         tool_module.show(use_context=True)

--- a/avalon/toonboom/avalon.js
+++ b/avalon/toonboom/avalon.js
@@ -181,7 +181,7 @@ function start()
       {
         "module": "avalon.toonboom",
         "method": "show",
-        "args": ["avalon.tools.workfiles"]
+        "args": ["pype.tools.workfiles"]
       },
       false
     );

--- a/avalon/toonboom/lib.py
+++ b/avalon/toonboom/lib.py
@@ -13,7 +13,7 @@ import filecmp
 from uuid import uuid4
 
 from .server import Server
-from ..tools import workfiles
+from pype.tools import workfiles
 from ..vendor.Qt import QtWidgets
 
 self = sys.modules[__name__]

--- a/avalon/tvpaint/communication_server.py
+++ b/avalon/tvpaint/communication_server.py
@@ -264,7 +264,7 @@ class AvalonToolsHelper:
         if self._workfiles_tool is not None:
             return self._workfiles_tool
 
-        from ..tools.workfiles.app import (
+        from pype.tools.workfiles.app import (
             Window, validate_host_requirements
         )
         # Host validation

--- a/avalon/tvpaint/communication_server.py
+++ b/avalon/tvpaint/communication_server.py
@@ -278,7 +278,6 @@ class AvalonToolsHelper:
         )
 
         # window.setStyleSheet(style.load_stylesheet())
-        window.widgets["files"].widgets["save"].setEnabled(True)
 
         context = {
             "asset": api.Session["AVALON_ASSET"],

--- a/res/houdini/MainMenuCommon.XML
+++ b/res/houdini/MainMenuCommon.XML
@@ -63,7 +63,7 @@ publish.show(parent=pipeline.get_main_window())
                 <label>Work Files ..</label>
                 <scriptCode><![CDATA[
 import hou
-from pype.tools import workfiles
+from avalon.tools import workfiles
 from avalon.houdini import pipeline
 workfiles.show(parent=pipeline.get_main_window())
                 ]]></scriptCode>

--- a/res/houdini/MainMenuCommon.XML
+++ b/res/houdini/MainMenuCommon.XML
@@ -63,7 +63,7 @@ publish.show(parent=pipeline.get_main_window())
                 <label>Work Files ..</label>
                 <scriptCode><![CDATA[
 import hou
-from avalon.tools import workfiles
+from pype.tools import workfiles
 from avalon.houdini import pipeline
 workfiles.show(parent=pipeline.get_main_window())
                 ]]></scriptCode>


### PR DESCRIPTION
## Issue
Avalon's workfiles tool may not work properly in Pype 3 as there were needed some changes. To be able change usage of workfiles tools in most of hosts requires to change imports inside their implementation which is in avalon module.

Pype's workfile tool is currently used only in nuke or maya. This is change is for remaining hosts.

## Changes
- changed imports of workfile tool in avalon's host implementation

## Test
- [x] Harmony
- [x] Aftereffects + Photoshop
- [x] Blender
- [x] TVPaint
- [x] Houdini