### PR TITLE
Forwards compatible config

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -580,13 +580,10 @@ class Application(Action):
             "name": session["AVALON_ASSET"]
         })
         tools = self.find_tools(asset)
-        # Forwards compatibility
+        # Forwards compatibility - replace slash with underscore
         modified_tools = []
         for tool in tools:
-            parts = tool.split("/")
-            if len(parts) > 1:
-                parts.pop(0)
-            modified_tools.append("/".join(parts))
+            modified_tools.append(tool.replace("/", "_"))
         tools_attr.extend(modified_tools)
 
         tools_env = acre.get_tools(tools_attr)

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -580,7 +580,14 @@ class Application(Action):
             "name": session["AVALON_ASSET"]
         })
         tools = self.find_tools(asset)
-        tools_attr.extend(tools)
+        # Forwards compatibility
+        modified_tools = []
+        for tool in tools:
+            parts = tool.split("/")
+            if len(parts) > 1:
+                parts.pop(0)
+            modified_tools.append("/".join(parts))
+        tools_attr.extend(modified_tools)
 
         tools_env = acre.get_tools(tools_attr)
         dyn_env = acre.compute(tools_env)


### PR DESCRIPTION
Forwards compatible changes for Pype 3.

## Changes
- tools are split by slash `"/"` before loading of tool's environments
    - this is because tools are stored with slash in Pype 3 where separate tool's group name and tool's variant name (See in [PR](https://github.com/pypeclub/pype/pull/1190) )

|:black_flag: |this depends on|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1197|
|pype-config|https://github.com/pypeclub/pype-config/pull/105|