### PR TITLE
Fix TVPaint groups_data function

### DIFF
--- a/avalon/tvpaint/lib.py
+++ b/avalon/tvpaint/lib.py
@@ -192,6 +192,7 @@ def groups_data():
 
     output = parse_group_data(data)
     os.remove(output_filepath)
+    return output
 
 
 def get_layers_pre_post_behavior(layer_ids):


### PR DESCRIPTION
Pype 3 version of https://github.com/pypeclub/avalon-core/pull/314

## Issue
- return output of `groups_data` function in TVPaint's lib is missing

## Changes
- return output of `groups_data` function

||Pype 2 PRs|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/314|