### PR TITLE
Fix sync server visibility not enabled

### DIFF
--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -13,6 +13,8 @@ from .widgets import (
     RepresentationWidget
 )
 
+from openpype.modules import ModulesManager
+
 module = sys.modules[__name__]
 module.window = None
 
@@ -66,14 +68,17 @@ class Window(QtWidgets.QDialog):
         thumbnail = ThumbnailWidget(io)
         representations = RepresentationWidget(io)
 
+        manager = ModulesManager()
+        sync_server = manager.modules_by_name["sync_server"]
+
         thumb_ver_splitter = QtWidgets.QSplitter()
         thumb_ver_splitter.setOrientation(QtCore.Qt.Vertical)
         thumb_ver_splitter.addWidget(thumbnail)
         thumb_ver_splitter.addWidget(version)
-        thumb_ver_splitter.addWidget(representations)
+        if sync_server.enabled:
+            thumb_ver_splitter.addWidget(representations)
         thumb_ver_splitter.setStretchFactor(0, 30)
         thumb_ver_splitter.setStretchFactor(1, 35)
-        thumb_ver_splitter.setStretchFactor(2, 35)
 
         # Create splitter to show / hide family filters
         asset_filter_splitter = QtWidgets.QSplitter()
@@ -89,7 +94,6 @@ class Window(QtWidgets.QDialog):
         split.addWidget(asset_filter_splitter)
         split.addWidget(subsets)
         split.addWidget(thumb_ver_splitter)
-        split.setSizes([250, 1000, 550])
 
         container_layout.addWidget(split)
 
@@ -139,7 +143,12 @@ class Window(QtWidgets.QDialog):
         self._assetschanged()
 
         # Defaults
-        self.resize(1800, 900)
+        if sync_server.enabled:
+            split.setSizes([250, 1000, 550])
+            self.resize(1800, 900)
+        else:
+            split.setSizes([250, 850, 200])
+            self.resize(1300, 700)
 
     # -------------------------------
     # Delay calling blocking methods

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -381,7 +381,7 @@ class SubsetsModel(TreeModel):
             "last_versions_by_subset_id": last_versions_by_subset_id
         }
 
-        if self.sync_server:
+        if self.sync_server.enabled:
             version_ids = set()
             for _subset_id, doc in last_versions_by_subset_id.items():
                 version_ids.add(doc["_id"])
@@ -600,8 +600,9 @@ class SubsetsModel(TreeModel):
                     subset_doc["_id"]
                 )
                 data["last_version"] = last_version
-                data["repre_info"] = repre_info_by_version_id.get(
-                    last_version["_id"])
+                if repre_info_by_version_id:
+                    data["repre_info"] = repre_info_by_version_id.get(
+                        last_version["_id"])
 
                 item = Item()
                 item.update(data)

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -715,7 +715,7 @@ class SubsetsModel(TreeModel):
                                 }}
             }},
             {'$addFields': {
-                'progress_local': {'$first': {
+                'progress_local': {"$arrayElemAt": [{
                     '$cond': [{'$size': "$order_local.progress"},
                               "$order_local.progress",
                               # if exists created_dt count is as available
@@ -724,7 +724,7 @@ class SubsetsModel(TreeModel):
                                   [1],
                                   [0]
                               ]}
-                              ]}}
+                              ]}, 0]}
             }},
             {'$group': {  # first group by repre
                 '_id': '$_id',

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -201,7 +201,7 @@ class SubsetWidget(QtWidgets.QWidget):
             idx = model.Columns.index(column_name)
             view.setColumnWidth(idx, width)
 
-        if not model.sync_server:
+        if not model.sync_server or not model.sync_server.enabled:
             lib.change_visibility(self.model, self.view, "repre_info", False)
 
         selection = view.selectionModel()


### PR DESCRIPTION
Tweaked visibility of columns required only when SyncServer is enabled.

Fixed '$first' unavailability in MongoDB < 4.4
