### PR TITLE
Blender Publish GUI execution

### DIFF
--- a/avalon/blender/ops.py
+++ b/avalon/blender/ops.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import platform
 from functools import partial
 from pathlib import Path
 from types import ModuleType
@@ -63,20 +64,6 @@ class BlenderApplication(QtWidgets.QApplication):
         return cls.blender_windows.get(identifier)
 
 
-def _has_visible_windows(app: QtWidgets.QApplication) -> bool:
-    """Check if the Qt application has any visible top level windows."""
-    is_visible = False
-    for window in BlenderApplication.blender_windows.values():
-        try:
-            if window.isVisible():
-                is_visible = True
-                break
-        except RuntimeError:
-            continue
-
-    return is_visible
-
-
 def _process_app_events(app: QtWidgets.QApplication) -> Optional[float]:
     """Process the events of the Qt app if the window is still visible.
 
@@ -84,10 +71,13 @@ def _process_app_events(app: QtWidgets.QApplication) -> Optional[float]:
     return the time after which this function should be run again. Else return
     None, so the function is not run again and will be unregistered.
     """
+    if platform.system().lower() == "windows":
+        return None
+
     if OpenFileCacher.opening_file:
         return TIMER_INTERVAL
 
-    if app._instance and _has_visible_windows(app):
+    if app._instance:
         app.processEvents()
         return TIMER_INTERVAL
 
@@ -215,7 +205,16 @@ class LaunchPublisher(LaunchQtApp):
     bl_idname = "wm.avalon_publisher"
     bl_label = "Publish..."
 
-    _window = pyblish_pype_app
+    def execute(self, context):
+        wm = bpy.context.window_manager
+        if not wm.get('is_avalon_qt_timer_running', False):
+            bpy.app.timers.register(
+                partial(_process_app_events, self._app),
+                persistent=True,
+            )
+            wm['is_avalon_qt_timer_running'] = True
+
+        pyblish_pype_app.show()
 
 
 class LaunchManager(LaunchQtApp):

--- a/avalon/blender/ops.py
+++ b/avalon/blender/ops.py
@@ -14,7 +14,7 @@ from ..tools.creator.app import Window as creator_window
 from ..tools.loader.app import Window as loader_window
 from ..tools.workfiles.app import Window as workfiles_window
 from ..tools.sceneinventory.app import Window as sceneinventory_window
-from ..tools import publish
+from pype.tools.pyblish_pype import app as pyblish_pype_app
 
 from .. import api
 from ..vendor.Qt import QtWidgets, QtCore
@@ -211,10 +211,7 @@ class LaunchPublisher(LaunchQtApp):
     bl_idname = "wm.avalon_publisher"
     bl_label = "Publish..."
 
-    def execute(self, context):
-        publish_show = publish._discover_gui()
-        publish.show()
-        return {'FINISHED'}
+    _window = pyblish_pype_app
 
 
 class LaunchManager(LaunchQtApp):

--- a/avalon/blender/ops.py
+++ b/avalon/blender/ops.py
@@ -16,6 +16,7 @@ from ..tools.workfiles.app import Window as workfiles_window
 from ..tools.sceneinventory.app import Window as sceneinventory_window
 from pype.tools.pyblish_pype import app as pyblish_pype_app
 
+from .workio import OpenFileCacher
 from .. import api
 from ..vendor.Qt import QtWidgets, QtCore
 
@@ -83,6 +84,9 @@ def _process_app_events(app: QtWidgets.QApplication) -> Optional[float]:
     return the time after which this function should be run again. Else return
     None, so the function is not run again and will be unregistered.
     """
+    if OpenFileCacher.opening_file:
+        return TIMER_INTERVAL
+
     if app._instance and _has_visible_windows(app):
         app.processEvents()
         return TIMER_INTERVAL

--- a/avalon/blender/workio.py
+++ b/avalon/blender/workio.py
@@ -7,8 +7,27 @@ import bpy
 from avalon import api
 
 
+class OpenFileCacher:
+    """Store information about opening file.
+
+    When file is opening QApplcation events should not be processed.
+    """
+    opening_file = False
+
+    @classmethod
+    def post_load(cls):
+        cls.opening_file = False
+        bpy.app.handlers.load_post.remove(cls.post_load)
+
+    @classmethod
+    def set_opening(cls):
+        cls.opening_file = True
+        bpy.app.handlers.load_post.append(cls.post_load)
+
+
 def open_file(filepath: str) -> Optional[str]:
     """Open the scene file in Blender."""
+    OpenFileCacher.set_opening()
 
     preferences = bpy.context.preferences
     load_ui = preferences.filepaths.use_load_ui


### PR DESCRIPTION
## Issue
QApplication should know about vibile and not visible windows to know if should process events or not. Publish UI is not stored to known opened windows so can't determine if should paint and execute logic. This happens only on specific versions of blender and on linux.

## Changes
- pyblish gui is used directly from Pype
- Qt application processing of events is executed only on linux

||OpenPype 3 PRs|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/320|