### PR TITLE
Blender Publish GUI execution

### DIFF
--- a/avalon/blender/ops.py
+++ b/avalon/blender/ops.py
@@ -14,7 +14,7 @@ from ..tools.creator.app import Window as creator_window
 from ..tools.loader.app import Window as loader_window
 from openpype.tools.workfiles.app import Window as workfiles_window
 from ..tools.sceneinventory.app import Window as sceneinventory_window
-from ..tools import publish
+from openpype.tools.pyblish_pype import app as pyblish_pype_app
 
 from .. import api
 from ..vendor.Qt import QtWidgets, QtCore
@@ -210,11 +210,7 @@ class LaunchPublisher(LaunchQtApp):
 
     bl_idname = "wm.avalon_publisher"
     bl_label = "Publish..."
-
-    def execute(self, context):
-        publish_show = publish._discover_gui()
-        publish.show()
-        return {'FINISHED'}
+    _window = pyblish_pype_app
 
 
 class LaunchManager(LaunchQtApp):


### PR DESCRIPTION
## Issue
QApplication should know about vibile and not visible windows to know if should process events or not. Publish UI is not stored to known opened windows so can't determine if should paint and execute logic. This happens only on specific versions of blender and on linux.

## Changes
- use publish gui directly from `pyblish_pype` which cause that window is stored to known windows and is checked if is visible or not

||Pype 2 PRs|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/319|