### PR TITLE
Sorted values in Switch Asset tool

### DIFF
--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -951,7 +951,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
         # Fill combobox
         if values is not None:
-            combobox_widget.populate(values)
+            combobox_widget.populate(list(sorted(values)))
             if selected_value and selected_value in values:
                 index = None
                 for idx in range(combobox_widget.count()):


### PR DESCRIPTION
## Descritpion
- values in Swtich Asset UI are populated to comboboxes in random order which is confusing

## Changes
- pass values to comboboxes sorted

||OpenPype 3 PRs|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/323|