### PR TITLE
Fix failure in LibraryLoader if no Sync Server

### DIFF
--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -189,6 +189,17 @@ class SubsetsModel(TreeModel):
                     "type": "version",
                     "parent": parent
                 })
+
+                # update availability on active site when version changes
+                if self.sync_server.enabled and version:
+                    site = self.active_site
+                    query = self._repre_per_version_pipeline([version["_id"]],
+                                                             site)
+                    docs = list(self.dbcon.aggregate(query))
+                    if docs:
+                        repre = docs.pop()
+                        version["data"].update(self._get_repre_dict(repre))
+
             self.set_version(index, version)
 
         return super(SubsetsModel, self).setData(index, value, role)
@@ -274,13 +285,10 @@ class SubsetsModel(TreeModel):
             "step": version_data.get("step", None),
         })
 
-        repre_info = item.get("repre_info")
+        repre_info = version_data.get("repre_info")
         if repre_info:
-            repres = "{}/{}".format(
-                int(math.floor(float(repre_info['avail_repre']))),
-                int(math.floor(float(repre_info['repre_count']))))
-            item["repre_info"] = repres
-            item["repre_icon"] = self.repre_icons.get(repre_info["provider"])
+            item["repre_info"] = repre_info
+            item["repre_icon"] = version_data.get("repre_icon")
 
     def _fetch(self):
         asset_docs = self.dbcon.find(
@@ -569,6 +577,10 @@ class SubsetsModel(TreeModel):
                     )
                     data["last_version"] = last_version
 
+                    data.update(
+                        self._get_last_repre_info(repre_info_by_version_id,
+                                                  last_version["_id"]))
+
                     item = Item()
                     item.update(data)
                     self.add_child(item, _parent_item)
@@ -599,9 +611,9 @@ class SubsetsModel(TreeModel):
                     subset_doc["_id"]
                 )
                 data["last_version"] = last_version
-                if repre_info_by_version_id:
-                    data["repre_info"] = repre_info_by_version_id.get(
-                        last_version["_id"])
+
+                data.update(self._get_last_repre_info(repre_info_by_version_id,
+                                                      last_version["_id"]))
 
                 item = Item()
                 item.update(data)
@@ -700,6 +712,27 @@ class SubsetsModel(TreeModel):
                 return self.column_labels_mapping.get(key) or key
 
         super(TreeModel, self).headerData(section, orientation, role)
+
+    def _get_last_repre_info(self, repre_info_by_version_id, last_version_id):
+        data = {}
+        if repre_info_by_version_id:
+            repre_info = repre_info_by_version_id.get(last_version_id)
+            return self._get_repre_dict(repre_info)
+
+        return data
+
+    def _get_repre_dict(self, repre_info):
+        """Returns icon and str representation of availability"""
+        data = {}
+        if repre_info:
+            repres_str = "{}/{}".format(
+                int(math.floor(float(repre_info['avail_repre']))),
+                int(math.floor(float(repre_info['repre_count']))))
+
+            data["repre_info"] = repres_str
+            data["repre_icon"] = self.repre_icons.get(self.active_provider)
+
+        return data
 
     def _repre_per_version_pipeline(self, version_ids, site):
         query = [


### PR DESCRIPTION
Change of version in LibraryLoader and Loader resulted in runtime exception if Sync Server wasn't enabled.
