### PR TITLE
SubsetLoader and support multiple contexts

### DIFF
--- a/avalon/api.py
+++ b/avalon/api.py
@@ -21,6 +21,7 @@ from .pipeline import (
     CreatorError,
 
     Loader,
+    SubsetLoader,
     Creator,
     Action,
     InventoryAction,
@@ -88,6 +89,7 @@ __all__ = [
     "CreatorError",
 
     "Loader",
+    "SubsetLoader",
     "Creator",
     "Action",
     "InventoryAction",
@@ -118,6 +120,8 @@ __all__ = [
     "register_plugin_path",
     "register_plugin",
     "register_root",
+
+    "last_discovered_plugins",
 
     "registered_root",
     "registered_plugin_paths",

--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -93,8 +93,7 @@ class Window(QtWidgets.QDialog):
         manager = ModulesManager()
         sync_server = manager.modules_by_name["sync_server"]
 
-        # RepresentationWidget needs dbcon from environments, eg. io
-        representations = RepresentationWidget(None)
+        representations = RepresentationWidget(self.dbcon)
 
         thumb_ver_splitter = QtWidgets.QSplitter()
         thumb_ver_splitter.setOrientation(QtCore.Qt.Vertical)

--- a/avalon/tools/loader/lib.py
+++ b/avalon/tools/loader/lib.py
@@ -1,7 +1,7 @@
+import inspect
 from ...vendor.Qt import QtGui
 from ...vendor import qtawesome
 from ..widgets import OptionalAction, OptionDialog
-import inspect
 
 
 def change_visibility(model, view, column_name, visible):
@@ -68,7 +68,7 @@ def add_representation_loaders_to_menu(loaders, menu):
     # List the available loaders
     for representation, loader in loaders:
         label = None
-        if representation.get("custom_label"):
+        if representation:
             label = representation.get("custom_label")
 
         if not label:

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -1002,22 +1002,32 @@ class RepresentationWidget(QtWidgets.QWidget):
         available_loaders = api.discover(api.Loader)
 
         loaders = list()
+        filtered_loaders = []
         for loader in available_loaders:
-            if tools_lib.is_representation_loader(loader):
-                if not self.sync_server_enabled:
-                    available_loaders.remove(loader)
+            # Skip subset loaders
+            if api.SubsetLoader in inspect.getmro(loader):
+                continue
+
+            if (
+                tools_lib.is_representation_loader(loader)
+                and not self.sync_server_enabled
+            ):
+                continue
+
+            filtered_loaders.append(loader)
 
         if self.tool_name:
-            available_loaders = lib.remove_tool_name_from_loaders(
-                available_loaders, self.tool_name)
+            filtered_loaders = lib.remove_tool_name_from_loaders(
+                filtered_loaders, self.tool_name
+            )
 
         already_added_loaders = set()
         label_already_in_menu = set()
         for item in items:
             repre_context = pipeline.get_representation_context(item["_id"])
             for loader in pipeline.loaders_from_repre_context(
-                    available_loaders,
-                    repre_context
+                filtered_loaders,
+                repre_context
             ):
                 if tools_lib.is_representation_loader(loader):
                     both_unavailable = item["active_site_progress"] <= 0 and \

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -1058,7 +1058,6 @@ class RepresentationWidget(QtWidgets.QWidget):
         # index under the cursor, so we can list the user the options.
         available_loaders = api.discover(api.Loader)
 
-        loaders = list()
         filtered_loaders = []
         for loader in available_loaders:
             # Skip subset loaders
@@ -1078,6 +1077,7 @@ class RepresentationWidget(QtWidgets.QWidget):
                 filtered_loaders, self.tool_name
             )
 
+        loaders = list()
         already_added_loaders = set()
         label_already_in_menu = set()
 


### PR DESCRIPTION
OpenPype 3 version of [PR](https://github.com/pypeclub/avalon-core/pull/329)

- SubsetLoader only appears once in the right click menu.
- If a SubsetLoader support multiple contexts with `is_multiple_context_compatible` attribute, it'll get a list of contexts passed to its `load` method.

## Additional changes
- partially fixed `RepresentationWidget` in library loader
    - `AvalonMongoDB` was not passed to widget and widget internally used `avalon.io`
- added filtering of `SubsetLoader` inside `RepresentationWidget`

||Pype 2 PRs|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/329|
|pype|https://github.com/pypeclub/OpenPype/pull/1484|

||Relates to PRs|
|---|---|
|OpenPype|https://github.com/pypeclub/OpenPype/pull/1497|