### PR TITLE
Existing subsets hints in creator

### DIFF
--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -349,9 +349,9 @@ class Window(QtWidgets.QDialog):
                 defaults = list(plugin.defaults)
 
             # Replace
-            compare_regex = re.compile(
-                subset_name.replace(user_input_text, "(.+)")
-            )
+            compare_regex = re.compile(re.sub(
+                user_input_text, "(.+)", subset_name, flags=re.IGNORECASE
+            ))
             subset_hints = set()
             if user_input_text:
                 for _name in existing_subset_names:


### PR DESCRIPTION
## Issue
Subset hints in Creator tool dropdown do not find out other possible user inputs if user intup has different letter case than concatenated subset name. That is because user input is replaced in concatenated subset name to get possible regex to find other possible user inputs.
```
user_input = "anim"
subset_name = "renderCompositingAnim"
expected_regex = "renderCompositing(.+)"
real_regex = "renderCompositingAnim"
```

## Changes
- replacement of user input in concatenated subset name is not case sensitive

||Related Prs|
|---|---|
|OpenPype|https://github.com/pypeclub/OpenPype/pull/1503|

||Pype 2 PRs|
|---|---|
|pype|https://github.com/pypeclub/OpenPype/pull/1502|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/333|