### PR TITLE
PS, AE - send actual context when another webserver is running

### DIFF
--- a/avalon/aftereffects/lib.py
+++ b/avalon/aftereffects/lib.py
@@ -15,6 +15,7 @@ from wsrpc_aiohttp import (
 
 from Qt import QtWidgets
 
+from avalon import api
 from avalon.tools.webserver.app import WebServerTool
 
 from openpype.tools import workfiles
@@ -85,8 +86,10 @@ class AfterEffectsRoute(WebSocketRoute):
         log.info("Setting context change")
         log.info("project {} asset {} ".format(project, asset))
         if project:
+            api.Session["AVALON_PROJECT"] = project
             os.environ["AVALON_PROJECT"] = project
         if asset:
+            api.Session["AVALON_ASSET"] = asset
             os.environ["AVALON_ASSET"] = asset
 
     async def read(self):

--- a/avalon/aftereffects/lib.py
+++ b/avalon/aftereffects/lib.py
@@ -75,7 +75,7 @@ class AfterEffectsRoute(WebSocketRoute):
 
     # This method calls function on the client side
     # client functions
-    async def set_context(self, project, asset):
+    async def set_context(self, project, asset, task):
         """
             Sets 'project' and 'asset' to envs, eg. setting context
 
@@ -91,6 +91,9 @@ class AfterEffectsRoute(WebSocketRoute):
         if asset:
             api.Session["AVALON_ASSET"] = asset
             os.environ["AVALON_ASSET"] = asset
+        if task:
+            api.Session["AVALON_TASK"] = task
+            os.environ["AVALON_TASK"] = task
 
     async def read(self):
         log.debug("aftereffects.read client calls server server calls "

--- a/avalon/photoshop/lib.py
+++ b/avalon/photoshop/lib.py
@@ -15,6 +15,7 @@ from wsrpc_aiohttp import (
 
 from Qt import QtWidgets
 
+from avalon import api
 from avalon.tools.webserver.app import WebServerTool
 
 from openpype.tools import workfiles
@@ -85,8 +86,10 @@ class PhotoshopRoute(WebSocketRoute):
         log.info("Setting context change")
         log.info("project {} asset {} ".format(project, asset))
         if project:
+            api.Session["AVALON_PROJECT"] = project
             os.environ["AVALON_PROJECT"] = project
         if asset:
+            api.Session["AVALON_ASSET"] = asset
             os.environ["AVALON_ASSET"] = asset
 
     async def read(self):

--- a/avalon/photoshop/lib.py
+++ b/avalon/photoshop/lib.py
@@ -75,7 +75,7 @@ class PhotoshopRoute(WebSocketRoute):
 
     # This method calls function on the client side
     # client functions
-    async def set_context(self, project, asset):
+    async def set_context(self, project, asset, task):
         """
             Sets 'project' and 'asset' to envs, eg. setting context
 
@@ -91,6 +91,9 @@ class PhotoshopRoute(WebSocketRoute):
         if asset:
             api.Session["AVALON_ASSET"] = asset
             os.environ["AVALON_ASSET"] = asset
+        if task:
+            api.Session["AVALON_TASK"] = task
+            os.environ["AVALON_TASK"] = task
 
     async def read(self):
         log.debug("photoshop.read client calls server server calls "

--- a/avalon/photoshop/lib.py
+++ b/avalon/photoshop/lib.py
@@ -8,6 +8,7 @@ import logging
 import functools
 import time
 import traceback
+import asyncio
 
 from wsrpc_aiohttp import (
     WebSocketRoute,
@@ -101,6 +102,20 @@ class PhotoshopRoute(WebSocketRoute):
 
     # This method calls function on the client side
     # client functions
+    async def set_context(self, project, asset):
+        """
+            Sets 'project' and 'asset' to envs, eg. setting context
+
+            Args:
+                project (str)
+                asset (str)
+        """
+        log.info("Setting context change")
+        log.info("project {} asset {} ".format(project, asset))
+        if project:
+            os.environ["AVALON_PROJECT"] = project
+        if asset:
+            os.environ["AVALON_ASSET"] = asset
 
     async def read(self):
         log.debug("photoshop.read client calls server server calls "
@@ -154,7 +169,6 @@ def stub():
 def safe_excepthook(*args):
     traceback.print_exception(*args)
 
-
 def launch(*subprocess_args):
     """Starts the websocket server that will be hosted
        in the Photoshop extension.
@@ -167,6 +181,13 @@ def launch(*subprocess_args):
     process = subprocess.Popen(subprocess_args, stdout=subprocess.PIPE)
 
     websocket_server = WebServerTool()
+
+    if websocket_server.port_occupied(websocket_server.host_name,
+                                      websocket_server.port):
+        log.info("Server already running, sending actual context and exit")
+        asyncio.run(websocket_server.send_context_change())
+        sys.exit(1)
+
     # Add Websocket route
     websocket_server.add_route("*", "/ws/", WebSocketAsync)
     # Add after effects route to websocket handler

--- a/avalon/tools/webserver/app.py
+++ b/avalon/tools/webserver/app.py
@@ -16,6 +16,8 @@ from wsrpc_aiohttp import (
     WSRPCClient
 )
 
+from avalon import api
+
 log = logging.getLogger(__name__)
 
 
@@ -78,12 +80,15 @@ class WebServerTool:
                              loop=asyncio.get_event_loop())
         await client.connect()
 
-        project = os.environ["AVALON_PROJECT"]
-        asset = os.environ["AVALON_ASSET"]
-        log.info("Sending context change to {}-{}".format(project, asset))
+        project = api.Session["AVALON_PROJECT"]
+        asset = api.Session["AVALON_ASSET"]
+        task = api.Session["AVALON_TASK"]
+        log.info("Sending context change to {}-{}-{}".format(project,
+                                                             asset,
+                                                             task))
 
         await client.call('{}.set_context'.format(host),
-                          project=project, asset=asset)
+                          project=project, asset=asset, task=task)
         await client.close()
 
     def port_occupied(self, host_name, port):

--- a/avalon/tools/webserver/app.py
+++ b/avalon/tools/webserver/app.py
@@ -8,8 +8,13 @@ import logging
 import urllib
 import threading
 import asyncio
+import socket
 
 from aiohttp import web
+
+from wsrpc_aiohttp import (
+    WSRPCClient
+)
 
 log = logging.getLogger(__name__)
 
@@ -31,17 +36,22 @@ class WebServerTool:
         self.on_stop_callbacks = []
 
         port = None
+        host_name = "localhost"
         websocket_url = os.getenv("WEBSOCKET_URL")
         if websocket_url:
             parsed = urllib.parse.urlparse(websocket_url)
             port = parsed.port
+            host_name = parsed.netloc.split(":")[0]
         if not port:
             port = 8098  # fallback
+
+        self.port = port
+        self.host_name = host_name
 
         self.app = web.Application()
 
         # add route with multiple methods for single "external app"
-        self.webserver_thread = WebServerThread(self, port)
+        self.webserver_thread = WebServerThread(self, self.port)
 
     def add_route(self, *args, **kwargs):
         self.app.router.add_route(*args, **kwargs)
@@ -55,6 +65,41 @@ class WebServerTool:
 
     def stop_server(self):
         self.stop()
+
+    async def send_context_change(self):
+        """
+            Calls running webserver to inform about context change
+
+            Used when new PS should be triggered, but one already running, without
+            this publish would point to old context.
+        """
+        client = WSRPCClient(os.getenv("WEBSOCKET_URL"),
+                             loop=asyncio.get_event_loop())
+        await client.connect()
+
+        project = os.environ["AVALON_PROJECT"]
+        asset = os.environ["AVALON_ASSET"]
+        log.info("Sending context change to {}-{}".format(project, asset))
+        await client.proxy.Photoshop.set_context(project=project, asset=asset)
+        await client.close()
+
+    def port_occupied(self, host_name, port):
+        """
+            Check if 'url' is already occupied.
+
+            This could mean, that app is already running and we are trying open it
+            again. In that case, use existing running webserver.
+            Check here is easier than capturing exception from thread.
+        """
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        result = True
+        try:
+            sock.bind((host_name, port))
+            result = False
+        except:
+            print("Port is in use")
+
+        return result
 
     def call(self, func):
         log.debug("websocket.call {}".format(func))
@@ -135,12 +180,13 @@ class WebServerThread(threading.Thread):
             log.warning(
                 "Websocket Server service has failed", exc_info=True
             )
+            raise
         finally:
             self.loop.close()  # optional
 
-        self.is_running = False
-        self.module.thread_stopped()
-        log.info("Websocket server stopped")
+            self.is_running = False
+            self.module.thread_stopped()
+            log.info("Websocket server stopped")
 
     async def start_server(self):
         """ Starts runner and TCPsite """


### PR DESCRIPTION
For cases that app is already running, but same app is triggered again from launcher or FTrack to save booting time

Requires:
https://github.com/pypeclub/OpenPype/pull/1811

How to test:
-------------
Open PS via Ftrack (or launcher) from one asset
Keep PS open
Try to open PS via FTrack (or launcher) from different asset
  - it should log that is sending context change, original PS is kept open, context should be changed (check after publish if representation were added to correct asset)


For PS it doesn't solve an issue that artist would switch between multiple opened workfiles. (AE doesn't allow that.)
Validator was added for PS to compare expected context with current, artist is informed and can decide to fix (replace) context, or reopen workfile via Workfiles app to refresh context.

