### PR TITLE
Feature #1191 subset manager shows deleted harmony

### DIFF
--- a/avalon/harmony/lib.py
+++ b/avalon/harmony/lib.py
@@ -323,7 +323,12 @@ def read(node_id):
 
 
 def remove(node_id):
-    """Remove node data from scene metadata."""
+    """
+        Remove node data from scene metadata.
+
+        Args:
+            node_id (str): full name (eg. 'Top/renderAnimation')
+    """
     data = get_scene_data()
     del data[node_id]
     set_scene_data(data)
@@ -479,8 +484,11 @@ def find_node_by_name(name, node_type):
     """Find node by its name.
 
     Args:
-        name (str): Name of the Node.
-        node_typ (str): Type of the Node.
+        name (str): Name of the Node. (without part before '/')
+        node_type (str): Type of the Node.
+            'READ' - for loaded data with Loaders (background)
+            'GROUP' - for loaded data with Loaders (templates)
+            'WRITE' - render nodes
 
     Returns:
         str: FQ Node name.

--- a/avalon/harmony/pipeline.py
+++ b/avalon/harmony/pipeline.py
@@ -47,14 +47,15 @@ def ls():
         yield data
 
 
-def list_instances():
+def list_instances(remove_orphaned=True):
     """
         List all created instances from current workfile which
         will be published.
 
         Pulls from File > File Info
 
-        For SubsetManager
+        For SubsetManager, by default it check if instance has matching node
+        in the scene, if not, instance gets deleted from metadata.
 
         Returns:
             (list) of dictionaries matching instances format
@@ -65,11 +66,21 @@ def list_instances():
         # Skip non-tagged objects.
         if not data:
             continue
+
         # Filter out containers.
         if "container" in data.get("id"):
             continue
 
         data['uuid'] = key
+
+        if remove_orphaned:
+            node_name = key.split("/")[-1]
+            located_node = lib.find_node_by_name(node_name, 'WRITE')
+            if not located_node:
+                print("Removing orphaned instance {}".format(key))
+                lib.remove(key)
+                continue
+
         instances.append(data)
 
     return instances
@@ -77,7 +88,7 @@ def list_instances():
 
 def remove_instance(instance):
     """
-        Remove instance from current workfile metadata.
+        Remove instance from current workfile metadata and from scene!
 
         Updates metadata of current file in File > File Info and removes
         icon highlight on group layer.


### PR DESCRIPTION
Closes: https://github.com/pypeclub/OpenPype/issues/1191

SubsetManager cleans all instances which haven't matching write node in scene anytime is opened.

Publish is handled already as its looping through physical nodes, not metadata.

To test:

> Create instance
> Check that shows up in SubsetManager
> Delete created write node for a instance
> Check that instance is not showing in SubsetManager (and it isnt in Window>Metadata Editor)

