### PR TITLE
Blender post load callback fix

### DIFF
--- a/avalon/blender/pipeline.py
+++ b/avalon/blender/pipeline.py
@@ -42,6 +42,8 @@ def _on_load_post(*args):
     else:
         api.emit("new", args)
 
+    ops.OpenFileCacher.post_load()
+
 
 def _register_callbacks():
     """Register callbacks for certain events."""

--- a/avalon/blender/workio.py
+++ b/avalon/blender/workio.py
@@ -17,12 +17,10 @@ class OpenFileCacher:
     @classmethod
     def post_load(cls):
         cls.opening_file = False
-        bpy.app.handlers.load_post.remove(cls.post_load)
 
     @classmethod
     def set_opening(cls):
         cls.opening_file = True
-        bpy.app.handlers.load_post.append(cls.post_load)
 
 
 def open_file(filepath: str) -> Optional[str]:


### PR DESCRIPTION
## Issue
Callbacks on "open file" must be decorated with blender decorator to be able trigger it which was not used for callback which should reenable processing of Qt events.

## Changes
- callback is triggered with global blender implementation callback `_on_load_post` instead of separated method

## Note
- this issue happens on linux where Qt event can't be processed during workfile loading

||Pype 2 PRs|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/337|