### PR TITLE
Library loader refresh fix

### DIFF
--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -348,6 +348,13 @@ class Window(QtWidgets.QDialog):
         subsets_model.clear()
         self.clear_assets_underlines()
 
+        if not self.dbcon.Session.get("AVALON_PROJECT"):
+            subsets_widget.set_loading_state(
+                loading=False,
+                empty=True
+            )
+            return
+
         # filter None docs they are silo
         asset_docs = assets_widget.get_selected_assets()
         if len(asset_docs) == 0:

--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -37,6 +37,7 @@ class Window(QtWidgets.QDialog):
         super(Window, self).__init__(parent)
 
         self._initial_refresh = False
+        self._ignore_project_change = False
 
         # Enable minimize and maximize for app
         self.setWindowTitle(self.tool_title)
@@ -182,6 +183,8 @@ class Window(QtWidgets.QDialog):
         # Store current project
         old_project_name = self.current_project
 
+        self._ignore_project_change = True
+
         # Cleanup
         self.combo_projects.clear()
 
@@ -202,6 +205,8 @@ class Window(QtWidgets.QDialog):
         root_item.appendRows(combobox_items)
 
         index = 0
+        self._ignore_project_change = False
+
         if old_project_name:
             index = self.combo_projects.findText(
                 old_project_name, QtCore.Qt.MatchFixedString
@@ -222,6 +227,9 @@ class Window(QtWidgets.QDialog):
         return projects
 
     def on_project_change(self):
+        if self._ignore_project_change:
+            return
+
         row = self.combo_projects.currentIndex()
         index = self.combo_projects.model().index(row, 0)
         project_name = index.data(QtCore.Qt.UserRole + 1)

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -473,6 +473,7 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
         self.reset_sync_server()
 
         if not self._asset_ids:
+            self.doc_fetched.emit()
             return
 
         self.fetch_subset_and_version()
@@ -1191,4 +1192,3 @@ class RepresentationModel(TreeModel, BaseRepresentationModel):
             group[key] = (group.get(key, 0) + max(progress, 0))
 
         return group
-

--- a/avalon/tools/models.py
+++ b/avalon/tools/models.py
@@ -522,9 +522,6 @@ class AssetModel(TreeModel):
         # Clear model items
         self.clear()
 
-        if not self.dbcon.Session.get("AVALON_PROJECT"):
-            return
-
         # Fetch documents from mongo
         # Restart payload
         self._doc_payload = {}

--- a/avalon/tools/widgets.py
+++ b/avalon/tools/widgets.py
@@ -107,14 +107,6 @@ class AssetWidget(QtWidgets.QWidget):
         self._store_model_selection()
         time_start = time.time()
 
-        if not self.dbcon.Session.get("AVALON_PROJECT"):
-            self.refresh_triggered.emit()
-            self.set_loading_state(
-                loading=False,
-                empty=True
-            )
-            return
-
         self.set_loading_state(
             loading=True,
             empty=True


### PR DESCRIPTION
## Issue
- project change in library loader may cause a crash - this happens when project is set to None or when project refresh happens

```
Traceback (most WARNING:pyblish.plugin:Path already registered: C:\openpype\OpenPype\openpype\plugins\publish
recent call last):
  FilFetching asset..
e "C:\openpype\OpenPype\repos\avalon-core\avalon\tools\lib.py", line 557, in run
    func(*args, **kwargs)
  File "C:\openpype\OpenPype\repos\avalon-core\avalon\tools\loader\model.py", line 336, in _fetch
    asset_docs = self.dbcon.find(
  File "C:\openpype\OpenPype\repos\avalon-core\avalon\mongodb.py", line 307, in __getattr__
    self._database[self.active_project()],
  File "C:\openpype\OpenPype\.venv\lib\site-packages\pymongo\database.py", line 300, in __getitem__
    return Collection(self, name)
  File "C:\openpype\OpenPype\.venv\lib\site-packages\pymongo\collection.py", line 167, in __init__
    "of %s" % (string_type.__name__,))
TypeError: name must be an instance of str
```
## Changes
- ignore change of project on projects refresh
- removed few project checks and let all models clear properly if project is not set