### PR TITLE
TVPaint custom subset template

### DIFF
--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -318,10 +318,25 @@ class Window(QtWidgets.QDialog):
             # Force replacement of prohibited symbols
             # QUESTION should Creator care about this and here should be only
             #   validated with schema regex?
-            subset_name = re.sub(
+
+            # Allow curly brackets in subset name for dynamic keys
+            curly_left = "__cbl__"
+            curly_right = "__cbr__"
+            tmp_subset_name = (
+                subset_name
+                .replace("{", curly_left)
+                .replace("}", curly_right)
+            )
+            # Replace prohibited symbols
+            tmp_subset_name = re.sub(
                 "[^{}]+".format(SubsetAllowedSymbols),
                 "",
-                subset_name
+                tmp_subset_name
+            )
+            subset_name = (
+                tmp_subset_name
+                .replace(curly_left, "{")
+                .replace(curly_right, "}")
             )
             result.setText(subset_name)
 

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -507,13 +507,16 @@ class Window(QtWidgets.QDialog):
         Creator = item.data(PluginRole)
         use_selection = self.data["Use Selection Checkbox"].isChecked()
 
+        variant = self.data["Subset"].text()
+
         error_info = None
         try:
             api.create(
                 Creator,
                 subset_name,
                 asset,
-                options={"useSelection": use_selection}
+                options={"useSelection": use_selection},
+                data={"variant": variant}
             )
 
         except api.CreatorError as exc:

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -134,6 +134,7 @@ class Window(QtWidgets.QDialog):
         self.state = {
             "valid": False
         }
+        # Message dialog when something goes wrong during creation
         self.message_dialog = None
 
         body = QtWidgets.QWidget()
@@ -553,6 +554,7 @@ class Window(QtWidgets.QDialog):
                 family, subset_name, asset, *error_info
             )
             box.show()
+            # Store dialog so is not garbage collected before is shown
             self.message_dialog = box
 
         else:

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -134,6 +134,7 @@ class Window(QtWidgets.QDialog):
         self.state = {
             "valid": False
         }
+        self.message_dialog = None
 
         body = QtWidgets.QWidget()
         lists = QtWidgets.QWidget()
@@ -552,8 +553,10 @@ class Window(QtWidgets.QDialog):
                 family, subset_name, asset, *error_info
             )
             box.show()
+            self.message_dialog = box
 
-        self.echo("Created %s .." % subset_name)
+        else:
+            self.echo("Created %s .." % subset_name)
 
     def echo(self, message):
         widget = self.data["Error Message"]


### PR DESCRIPTION
## Desciption
Customizable subset template may currently break TVPaint `renderPass` and `renderLayer` families as their subset names are based on expectation of original template and the template is not used at the end. Because of that it is required to store user's input (variant) into instance data to be able handle that data afterwards.

## Changes
- store variant to data of instance data when creation is executed from creator tool
- enable curly brackets in subset name before executing "create" as it may identify unfilled dynamic keys that will be filled on creation
- raised `CreatorError` shows dialog

||Related to PRs|
|---|---|
|OpenPype|https://github.com/pypeclub/OpenPype/pull/1662|