### PR TITLE
TVPaint: Creator take layer name as default value for subset variant

### DIFF
--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -413,10 +413,15 @@ class Window(QtWidgets.QDialog):
         if plugin is None:
             return
 
-        if plugin.defaults and isinstance(plugin.defaults, list):
-            default = plugin.defaults[0]
-        else:
-            default = "Default"
+        default = None
+        if hasattr(plugin, "get_default_variant"):
+            default = plugin.get_default_variant()
+
+        if not default:
+            if plugin.defaults and isinstance(plugin.defaults, list):
+                default = plugin.defaults[0]
+            else:
+                default = "Default"
 
         name.setText(default)
 


### PR DESCRIPTION
## Description
Creator tool should have ability to ask Creator plugin to return default value for variant input.

## Changes
- creator tool can ask plugin to return default value for variant value with calling `get_default_variant`
    - this method does not have to be implemented so old way is kept and used if method is not implemented or won't return a value