### PR TITLE
Slash in paths fix

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1902,8 +1902,10 @@ def get_representation_path(representation, root=None, dbcon=None):
             # Template references unavailable data
             return None
 
+        # Check if path is empty string
+        # - `os.path.normpath` would convert "" to "." which always exists
         if not path:
-            return path
+            return None
 
         normalized_path = os.path.normpath(path)
         if os.path.exists(normalized_path):

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1893,6 +1893,11 @@ def get_representation_path(representation, root=None, dbcon=None):
             context = representation["context"]
             context["root"] = root
             path = format_template_with_optional_keys(context, template)
+            # Force replacing backslashes with forward slashed if not on
+            #   windows
+            if platform.system().lower() != "windows":
+                path = path.replace("\\", "/")
+
         except KeyError:
             # Template references unavailable data
             return None


### PR DESCRIPTION
## Issue
- template in representation may be stored with backslashes when published from windows which cause not working paths on linux and mac on load

## Changes
- replace backslashes with forward slasesh on linux and mac

Issue for OpenPype 3 was fixed with https://github.com/pypeclub/avalon-core/pull/324/files