### PR TITLE
Houdini: Import error in 2.x

### DIFF
--- a/avalon/io.py
+++ b/avalon/io.py
@@ -10,7 +10,7 @@ import contextlib
 
 from . import schema, Session
 from .vendor import requests
-from .api import AvalonMongoDB, session_data_from_environment
+from .mongodb import AvalonMongoDB, session_data_from_environment
 
 # Third-party dependencies
 from bson.objectid import ObjectId, InvalidId


### PR DESCRIPTION
Import cycle was breaking Avalon core initialization in Pype 2.x