### PR TITLE
Houdini: Import error in 3.x

### DIFF
--- a/avalon/io.py
+++ b/avalon/io.py
@@ -10,7 +10,7 @@ import contextlib
 
 from . import schema, Session
 from .vendor import requests
-from .api import AvalonMongoDB, session_data_from_environment
+from .mongodb import AvalonMongoDB, session_data_from_environment
 
 # Third-party dependencies
 from bson.objectid import ObjectId, InvalidId


### PR DESCRIPTION
## Issue
Import cycle was breaking Avalon core initialization in Pype 2.x

## Changes
Don't use api import in `io.py` to not cause circular import.

||OpenPype 2 PRs|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/351|