### PR TITLE
Adobe apps stdout/stderr definition

### DIFF
--- a/avalon/aftereffects/lib.py
+++ b/avalon/aftereffects/lib.py
@@ -185,8 +185,11 @@ def launch(*subprocess_args):
     sys.excepthook = safe_excepthook
 
     # Launch aftereffects and the websocket server.
-    ConsoleTrayApp.process = subprocess.Popen(subprocess_args,
-                                               stdout=subprocess.PIPE)
+    ConsoleTrayApp.process = subprocess.Popen(
+        subprocess_args,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL
+    )
 
     websocket_server = WebServerTool()
     route_name = 'AfterEffects'

--- a/avalon/harmony/lib.py
+++ b/avalon/harmony/lib.py
@@ -203,8 +203,11 @@ def launch_zip_file(filepath):
         return
 
     print("Launching {}".format(scene_path))
-    ConsoleTrayApp.process = subprocess.Popen([self.application_path,
-                                               scene_path])
+    ConsoleTrayApp.process = subprocess.Popen(
+        [self.application_path, scene_path],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL
+    )
     self.pid = ConsoleTrayApp.process.pid
 
 

--- a/avalon/photoshop/lib.py
+++ b/avalon/photoshop/lib.py
@@ -184,8 +184,11 @@ def launch(*subprocess_args):
     api.install(photoshop)
     sys.excepthook = safe_excepthook
     # Launch Photoshop and the websocket server.
-    ConsoleTrayApp.process = subprocess.Popen(subprocess_args,
-                                              stdout=subprocess.PIPE)
+    ConsoleTrayApp.process = subprocess.Popen(
+        subprocess_args,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL
+    )
 
     websocket_server = WebServerTool()
     route_name = 'Photoshop'


### PR DESCRIPTION
## Issue
Photoshop does not launch on MacOS when stdout is set to subprocess.PIPE and stderr is not defined
    - probably because does not have permissions to use it or can't use it

## Changes
- redirect stdout and stderr of adobe apps to devnull on launch