### PR TITLE
Loader options fix

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -252,6 +252,7 @@ class Loader(list):
         """
         return cls.options or []
 
+
 @lib.log
 class SubsetLoader(Loader):
     """Load subset into host application

--- a/avalon/tools/loader/lib.py
+++ b/avalon/tools/loader/lib.py
@@ -52,9 +52,8 @@ def get_options(action, loader, parent, repre_contexts):
     """
     # Pop option dialog
     options = {}
-
-    loader_options = loader.get_options(repre_contexts)
-    if loader_options:
+    if getattr(action, "optioned", False):
+        loader_options = loader.get_options(repre_contexts)
         dialog = OptionDialog(parent)
         dialog.setWindowTitle(action.label + " Options")
         dialog.create(loader_options)

--- a/avalon/tools/loader/lib.py
+++ b/avalon/tools/loader/lib.py
@@ -52,8 +52,8 @@ def get_options(action, loader, parent, repre_contexts):
     """
     # Pop option dialog
     options = {}
-    if getattr(action, "optioned", False):
-        loader_options = loader.get_options(repre_contexts)
+    loader_options = loader.get_options(repre_contexts)
+    if getattr(action, "optioned", False) and loader_options:
         dialog = OptionDialog(parent)
         dialog.setWindowTitle(action.label + " Options")
         dialog.create(loader_options)


### PR DESCRIPTION
## Issue
Now is options dialog during loadin shown all the time if options are available.

## Changes
- options dialog is shown only if was clicked on option subbutton

## How to test
### Prep
- have published representation that has loader with options
1. open host
2. load the representation without and with options and check if are loaded as expected