### PR TITLE
AvalonMongoDB auto install

### DIFF
--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -178,7 +178,7 @@ class AvalonMongoConnection:
 
     @classmethod
     def database(cls):
-        return cls._mongo_client[os.environ["AVALON_DB"]]
+        return cls._mongo_client[str(os.environ["AVALON_DB"])]
 
     @classmethod
     def mongo_client(cls):

--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -310,6 +310,10 @@ class AvalonMongoDB:
             )
 
         project_name = self.active_project()
+        if project_name is None:
+            raise ValueError(
+                "Value of 'Session[\"AVALON_PROJECT\"]' is not set."
+            )
 
         collection = self._database[project_name]
         not_set = object()

--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -299,7 +299,7 @@ class AvalonMongoDB:
 
     def __getattr__(self, attr_name):
         attr = None
-        if self.is_installed() and self.auto_install:
+        if not self.is_installed() and self.auto_install:
             self.install()
 
         if self.is_installed():

--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -378,21 +378,27 @@ class AvalonMongoDB:
 
     @requires_install
     @auto_reconnect
-    def projects(self):
+    def projects(self, query_filter=None, projection=None):
         """List available projects
 
         Returns:
             list of project documents
 
         """
+        if not query_filter:
+            query_filter = {"type": "project"}
+
+        find_args = [query_filter]
+        if projection:
+            find_args.append(projection)
+
         for project_name in self._database.collection_names():
             if project_name in ("system.indexes",):
                 continue
 
             # Each collection will have exactly one project document
-            document = self._database[project_name].find_one({
-                "type": "project"
-            })
+
+            document = self._database[project_name].find_one(*find_args)
             if document is not None:
                 yield document
 

--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -309,15 +309,19 @@ class AvalonMongoDB:
                 )
             )
 
-        attr = getattr(
-            self._database[project_name],
-            attr_name,
-            None
-        )
+        project_name = self.active_project()
 
-        if attr is None:
-            # Reraise attribute error
-            return self.__getattribute__(attr_name)
+        collection = self._database[project_name]
+        not_set = object()
+        attr = getattr(collection, attr_name, not_set)
+
+        if attr is not_set:
+            # Raise attribute error
+            raise AttributeError(
+                "{} has no attribute '{}'.".format(
+                    collection.__class__.__name__, attr_name
+                )
+            )
 
         # Decorate function
         if callable(attr):

--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -302,12 +302,18 @@ class AvalonMongoDB:
         if not self.is_installed() and self.auto_install:
             self.install()
 
-        if self.is_installed():
-            attr = getattr(
-                self._database[self.active_project()],
-                attr_name,
-                None
+        if not self.is_installed():
+            raise IOError(
+                "'{}.{}()' requires to run install() first".format(
+                    self.__class__.__name__, attr_name
+                )
             )
+
+        attr = getattr(
+            self._database[project_name],
+            attr_name,
+            None
+        )
 
         if attr is None:
             # Reraise attribute error


### PR DESCRIPTION
## Issue
Conditions in autoinstall are not working as expected and autoinstall does not work at all. Also `__getattr__` raises strange errors if something is not right.

## Changes
- autoinstall does work as expected
- when project is not set `ValueError` is raised
- when method is not available on collection `AttributeError` is raised
- `projects` method has ability to specify query filter and projection of documents
- environment `AVALON_DB` is converted to `str` as it may be `unicode` in python 2 hosts

### How to test
**Autoinstall**
- run this (e.g. in host)
```
from avalon.api import AvalonMongoDB

# Change to any of your project names
project_name = "Your project name"

# This should work without any issue
dbcon = AvalonMongoDB()
dbcon.Session["AVALON_PROJECT"] = project_name 
project_doc = dbcon.find_one({"type": "project"})

# This should raise IOError
dbcon = AvalonMongoDB(auto_install=False)
dbcon.Session["AVALON_PROJECT"] = project_name 
project_doc = dbcon.find_one({"type": "project"})

# This should raise Attribute error
dbcon = AvalonMongoDB()
dbcon.Session["AVALON_PROJECT"] = project_name 
project_doc = dbcon.damn_method({"type": "project"})
```