### PR TITLE
Normalize last workfile path.

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -2069,5 +2069,6 @@ def last_workfile(
         filename = format_template_with_optional_keys(data, file_template)
 
     if full_path:
-        return os.path.join(workdir, filename)
-    return filename
+        return os.path.normpath(os.path.join(workdir, filename))
+
+    return os.path.normpath(filename)

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -2071,4 +2071,4 @@ def last_workfile(
     if full_path:
         return os.path.normpath(os.path.join(workdir, filename))
 
-    return os.path.normpath(filename)
+    return filename


### PR DESCRIPTION
When returning the last workfile we need to normalize the path. Hosts like TVPaint have issues with non-normalized paths.