### PR TITLE
Loader: asset refresh bug

### DIFF
--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -354,7 +354,6 @@ class Window(QtWidgets.QDialog):
         self._versionschanged()
 
     def _versionschanged(self):
-
         subsets = self.data["widgets"]["subsets"]
         selection = subsets.view.selectionModel()
 
@@ -404,7 +403,6 @@ class Window(QtWidgets.QDialog):
 
         # representations.change_visibility("subset", len(rows) > 1)
         # representations.change_visibility("asset", len(asset_docs) > 1)
-
 
     def _set_context(self, context, refresh=True):
         """Set the selection in the interface using a context.
@@ -503,7 +501,6 @@ class Window(QtWidgets.QDialog):
 
 
 class SubsetGroupingDialog(QtWidgets.QDialog):
-
     grouped = QtCore.Signal()
 
     def __init__(self, items, groups_config, parent=None):

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -6,11 +6,16 @@ from ... import api, io, style, pipeline
 
 from ..models import AssetModel
 from ..widgets import AssetWidget
+
 from .. import lib
 
 from .widgets import (
-    SubsetWidget, VersionWidget, FamilyListWidget, ThumbnailWidget,
-    RepresentationWidget
+    SubsetWidget,
+    VersionWidget,
+    FamilyListWidget,
+    ThumbnailWidget,
+    RepresentationWidget,
+    OverlayFrame
 )
 
 from openpype.modules import ModulesManager
@@ -134,12 +139,18 @@ class Window(QtWidgets.QDialog):
             }
         }
 
+        overlay_frame = OverlayFrame("Loading...", self)
+        overlay_frame.setVisible(False)
+
         families.active_changed.connect(subsets.set_family_filters)
         assets.selection_changed.connect(self.on_assetschanged)
         assets.refresh_triggered.connect(self.on_assetschanged)
         assets.view.clicked.connect(self.on_assetview_click)
         subsets.active_changed.connect(self.on_subsetschanged)
         subsets.version_changed.connect(self.on_versionschanged)
+
+
+        self._overlay_frame = overlay_frame
 
         self.family_config_cache.refresh()
         self.groups_config.refresh()
@@ -154,6 +165,14 @@ class Window(QtWidgets.QDialog):
         else:
             split.setSizes([250, 850, 200])
             self.resize(1300, 700)
+
+    def resizeEvent(self, event):
+        super(Window, self).resizeEvent(event)
+        self._overlay_frame.resize(self.size())
+
+    def moveEvent(self, event):
+        super(Window, self).moveEvent(event)
+        self._overlay_frame.move(0, 0)
 
     # -------------------------------
     # Delay calling blocking methods

--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -149,6 +149,10 @@ class Window(QtWidgets.QDialog):
         subsets.active_changed.connect(self.on_subsetschanged)
         subsets.version_changed.connect(self.on_versionschanged)
 
+        subsets.load_started.connect(self._on_load_start)
+        subsets.load_ended.connect(self._on_load_end)
+        representations.load_started.connect(self._on_load_start)
+        representations.load_ended.connect(self._on_load_end)
 
         self._overlay_frame = overlay_frame
 
@@ -204,6 +208,19 @@ class Window(QtWidgets.QDialog):
         self.echo("Setting context: {}".format(context))
         lib.schedule(lambda: self._set_context(context, refresh=refresh),
                      50, channel="mongo")
+
+    def _on_load_start(self):
+        # Show overlay and process events so it's repainted
+        self._overlay_frame.setVisible(True)
+        QtWidgets.QApplication.processEvents()
+
+    def _hide_overlay(self):
+        self._overlay_frame.setVisible(False)
+
+    def _on_load_end(self):
+        # Delay hiding as click events happened during loading should be
+        #   blocked
+        QtCore.QTimer.singleShot(100, self._hide_overlay)
 
     # ------------------------------
 

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -114,6 +114,8 @@ class SubsetWidget(QtWidgets.QWidget):
 
     active_changed = QtCore.Signal()    # active index changed
     version_changed = QtCore.Signal()   # version state changed for a subset
+    load_started = QtCore.Signal()
+    load_ended = QtCore.Signal()
 
     default_widths = (
         ("subset", 200),
@@ -460,6 +462,8 @@ class SubsetWidget(QtWidgets.QWidget):
         # Find the representation name and loader to trigger
         action_representation, loader = action.data()
 
+        self.load_started.emit()
+
         if api.SubsetLoader in inspect.getmro(loader):
             subset_ids = []
             subset_version_docs = {}
@@ -511,6 +515,8 @@ class SubsetWidget(QtWidgets.QWidget):
             error_info = _load_representations_by_loader(
                 loader, repre_contexts, options=options
             )
+
+        self.load_ended.emit()
 
         if error_info:
             box = LoadErrorMessageBox(error_info)
@@ -948,6 +954,8 @@ class FamilyListWidget(QtWidgets.QListWidget):
 
 
 class RepresentationWidget(QtWidgets.QWidget):
+    load_started = QtCore.Signal()
+    load_ended = QtCore.Signal()
 
     default_widths = (
         ("name", 120),
@@ -1221,6 +1229,8 @@ class RepresentationWidget(QtWidgets.QWidget):
         if not action or not action.data():
             return
 
+        self.load_started.emit()
+
         # Find the representation name and loader to trigger
         action_representation, loader = action.data()
         repre_ids = []
@@ -1253,6 +1263,9 @@ class RepresentationWidget(QtWidgets.QWidget):
             options=options, data_by_repre_id=data_by_repre_id)
 
         self.model.refresh()
+
+        self.load_ended.emit()
+
         if errors:
             box = LoadErrorMessageBox(errors)
             box.show()

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -26,6 +26,26 @@ from .model import (
 from . import lib
 
 
+class OverlayFrame(QtWidgets.QFrame):
+    def __init__(self, label, parent):
+        super(OverlayFrame, self).__init__(parent)
+
+        label_widget = QtWidgets.QLabel(label, self)
+        main_layout = QtWidgets.QVBoxLayout(self)
+        main_layout.addWidget(label_widget, 1, QtCore.Qt.AlignCenter)
+
+        self.label_widget = label_widget
+
+        label_widget.setStyleSheet("background: transparent;")
+        self.setStyleSheet((
+            "background: rgba(0, 0, 0, 127);"
+            "font-size: 60pt;"
+        ))
+
+    def set_label(self, label):
+        self.label_widget.setText(label)
+
+
 class LoadErrorMessageBox(QtWidgets.QDialog):
     def __init__(self, messages, parent=None):
         super(LoadErrorMessageBox, self).__init__(parent)


### PR DESCRIPTION
## Issue
Asset view does not trigger selection changed signal if Qt process is used and someone clicks in the view at the same time.

## Suggested solution
- added overlay to window during loading which is hidden 100ms after loading so will block all click event meanwhile
    - it should not be possible to click on asset view during processing

Resolves https://github.com/pypeclub/OpenPype/issues/1878