### PR TITLE
Scene Manager: Pype 2 compatibility

### DIFF
--- a/avalon/tools/lib.py
+++ b/avalon/tools/lib.py
@@ -618,8 +618,7 @@ def get_progress_for_repre(doc, active_site, remote_site):
             if site.get("created_dt"):
                 progress[site["name"]] = norm_progress + 1
             elif site.get("progress"):
-                progress[site["name"]] = norm_progress + \
-                                         site["progress"]
+                progress[site["name"]] = norm_progress + site["progress"]
             else:  # site exists, might be failed, do not add again
                 progress[site["name"]] = 0
 

--- a/avalon/tools/lib.py
+++ b/avalon/tools/lib.py
@@ -598,18 +598,30 @@ def get_progress_for_repre(doc, active_site, remote_site):
         return progress
 
     files = {active_site: 0, remote_site: 0}
-    for file in doc.get("files", []):
-        for site in file.get("sites"):
-            if site["name"] in [active_site, remote_site]:
-                files[site["name"]] += 1
-                norm_progress = max(progress[site["name"]], 0)
-                if site.get("created_dt"):
-                    progress[site["name"]] = norm_progress + 1
-                elif site.get("progress"):
-                    progress[site["name"]] = norm_progress + \
-                                             site["progress"]
-                else:  # site exists, might be failed, do not add again
-                    progress[site["name"]] = 0
+    doc_files = doc.get("files") or []
+    for doc_file in doc_files:
+        if not isinstance(doc_file, dict):
+            continue
+
+        sites = doc_file.get("sites") or []
+        for site in sites:
+            if (
+                # Pype 2 compatibility
+                not isinstance(site, dict)
+                # Check if site name is one of progress sites
+                or site["name"] not in progress
+            ):
+                continue
+
+            files[site["name"]] += 1
+            norm_progress = max(progress[site["name"]], 0)
+            if site.get("created_dt"):
+                progress[site["name"]] = norm_progress + 1
+            elif site.get("progress"):
+                progress[site["name"]] = norm_progress + \
+                                         site["progress"]
+            else:  # site exists, might be failed, do not add again
+                progress[site["name"]] = 0
 
     # for example 13 fully avail. files out of 26 >> 13/26 = 0.5
     avg_progress = {}


### PR DESCRIPTION
## Issue
- scene manager is crashing when contain loaded representations created with pype 2

## Changes
- `get_progress_for_repre` does not crash with representations from pype 2