### PR TITLE
Removed orphaned import of mayalookassigner

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -114,8 +114,6 @@ def _install_menu():
         libraryloader
     )
 
-    import mayalookassigner
-
     from . import interactive
 
     _uninstall_menu()


### PR DESCRIPTION
Creates issues when running 'run_tests.ps1'

Requires: https://github.com/pypeclub/OpenPype/pull/1810
