### PR TITLE
Loader: Families filtering

### DIFF
--- a/avalon/tools/loader/app.py
+++ b/avalon/tools/loader/app.py
@@ -51,7 +51,7 @@ class Window(QtWidgets.QDialog):
 
         # Groups config
         self.groups_config = lib.GroupsConfig(io)
-        self.family_config_cache = lib.global_family_cache()
+        self.family_config_cache = lib.FamilyConfigCache(io)
 
         # Enable minimize and maximize for app
         self.setWindowFlags(QtCore.Qt.Window)

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -883,18 +883,16 @@ class FamiliesFilterProxyModel(GroupMemberFilterProxyModel):
             return self.filter_accepts_group(index, model)
 
         families = item.get("families", [])
-
-        filterable_families = set()
-        for name in families:
-            family_config = self.family_config_cache.family_config(name)
-            if not family_config.get("hideFilter"):
-                filterable_families.add(name)
-
-        if not filterable_families:
+        if not families:
             return True
 
+        family = tuple(families)[0]
+        family_config = self.family_config_cache.family_config(family)
+        if family_config.get("hideFilter"):
+            return False
+
         # We want to keep the families which are not in the list
-        return filterable_families.issubset(self._families)
+        return family in self._families
 
     def sort(self, column, order):
         proxy = self.sourceModel()

--- a/avalon/tools/loader/model.py
+++ b/avalon/tools/loader/model.py
@@ -865,7 +865,6 @@ class FamiliesFilterProxyModel(GroupMemberFilterProxyModel):
         self.invalidateFilter()
 
     def filterAcceptsRow(self, row=0, parent=None):
-
         if not self._families:
             return False
 
@@ -882,11 +881,10 @@ class FamiliesFilterProxyModel(GroupMemberFilterProxyModel):
         if item.get("isGroup"):
             return self.filter_accepts_group(index, model)
 
-        families = item.get("families", [])
-        if not families:
+        family = item.get("family")
+        if not family:
             return True
 
-        family = tuple(families)[0]
         family_config = self.family_config_cache.family_config(family)
         if family_config.get("hideFilter"):
             return False

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -880,7 +880,7 @@ class FamilyListWidget(QtWidgets.QListWidget):
                     "family": {"$arrayElemAt": ["$data.families", 0]}
                 }},
                 {"$group": {
-                    "_id": "tada",
+                    "_id": "family_group",
                     "families": {"$addToSet": "$family"}
                 }}
             ]))

--- a/avalon/tools/loader/widgets.py
+++ b/avalon/tools/loader/widgets.py
@@ -239,8 +239,8 @@ class SubsetWidget(QtWidgets.QWidget):
 
         self.model.refresh()
 
-        # Expose this from the widget as a method
-        self.set_family_filters = self.family_proxy.setFamiliesFilter
+    def set_family_filters(self, families):
+        self.family_proxy.setFamiliesFilter(families)
 
     def is_groupable(self):
         return self.data["state"]["groupable"].checkState()


### PR DESCRIPTION
## Changes
- families listed in family widget contain only main families (first family in subset `data.families`)
- filtering of subsets works as expected when families are checked/unchecked in family widget