### PR TITLE
Enable `AvalonMongoDB.projects()` filtering with 'data.active' field

### DIFF
--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -390,9 +390,9 @@ class AvalonMongoDB:
 
         find_args = [query_filter]
         if projection:
-            if no_archived:
-                projection.update({"data.archive_confirm": 1})
-            find_args.append(projection)
+            _projection = {"data.archived": 1}
+            _projection.update(projection)
+            find_args.append(_projection)
 
         for project_name in self._database.collection_names():
             if project_name in ("system.indexes",):
@@ -403,9 +403,11 @@ class AvalonMongoDB:
             doc = self._database[project_name].find_one(*find_args)
             if doc is not None:
 
-                if no_archived and \
-                        doc.get("data", {}).get("archive_confirm") == doc.get("name"):
+                if no_archived and doc.get("data", {}).get("archived"):
                     continue
+
+                if projection and not projection.get("data.archived"):
+                    doc.get("data", {}).pop("archived", None)
 
                 yield doc
 

--- a/avalon/mongodb.py
+++ b/avalon/mongodb.py
@@ -378,7 +378,7 @@ class AvalonMongoDB:
 
     @requires_install
     @auto_reconnect
-    def projects(self, query_filter=None, projection=None, no_archived=False):
+    def projects(self, query_filter=None, projection=None, only_active=True):
         """List available projects
 
         Returns:
@@ -390,8 +390,8 @@ class AvalonMongoDB:
 
         find_args = [query_filter]
         if projection:
-            _projection = {"data.archived": 1}
-            _projection.update(projection)
+            _projection = projection.copy()
+            _projection.update({"data.active": 1})
             find_args.append(_projection)
 
         for project_name in self._database.collection_names():
@@ -403,11 +403,11 @@ class AvalonMongoDB:
             doc = self._database[project_name].find_one(*find_args)
             if doc is not None:
 
-                if no_archived and doc.get("data", {}).get("archived"):
+                if only_active and not doc.get("data", {}).get("active", True):
                     continue
 
-                if projection and not projection.get("data.archived"):
-                    doc.get("data", {}).pop("archived", None)
+                if projection and not projection.get("data.active"):
+                    doc.get("data", {}).pop("active", None)
 
                 yield doc
 

--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -216,7 +216,7 @@ class Window(QtWidgets.QDialog):
 
     def get_filtered_projects(self):
         projects = list()
-        for project in self.dbcon.projects():
+        for project in self.dbcon.projects(no_archived=True):
             is_library = project.get("data", {}).get("library_project", False)
             if (
                 (is_library and self.show_libraries) or

--- a/avalon/tools/libraryloader/app.py
+++ b/avalon/tools/libraryloader/app.py
@@ -216,7 +216,7 @@ class Window(QtWidgets.QDialog):
 
     def get_filtered_projects(self):
         projects = list()
-        for project in self.dbcon.projects(no_archived=True):
+        for project in self.dbcon.projects(only_active=True):
             is_library = project.get("data", {}).get("library_project", False)
             if (
                 (is_library and self.show_libraries) or


### PR DESCRIPTION
## What's Changed

* The `AvalonMongoDB` object can now omit projects that has `data.active` field value set to `false` (consider project is active if `data.active` field doesn't exists).
* The argument `query_filter` of `AvalonMongoDB.projects()` method is now deprecated.

Example usage :
```python
from avalon.api import AvalonMongoDB
dbcon = AvalonMongoDB()
active_projects = [doc['name'] for doc in dbcon.projects(only_active=True)]
```