### PR TITLE
SceneInventory: Choose loader in asset switcher

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1554,7 +1554,7 @@ def update(container, version=-1):
     return loader.update(container, new_representation)
 
 
-def switch(container, representation):
+def switch(container, representation, loader_plugin=None):
     """Switch a container to representation
 
     Args:
@@ -1566,17 +1566,18 @@ def switch(container, representation):
     """
 
     # Get the Loader for this container
-    Loader = _get_container_loader(container)
+    if loader_plugin is None:
+        loader_plugin = _get_container_loader(container)
 
-    if not Loader:
+    if not loader_plugin:
         raise RuntimeError("Can't switch container. See log for details.")
 
-    if not hasattr(Loader, "switch"):
+    if not hasattr(loader_plugin, "switch"):
         # Backwards compatibility (classes without switch support
         # might be better to just have "switch" raise NotImplementedError
         # on the base class of Loader\
         raise RuntimeError("Loader '{}' does not support 'switch'".format(
-            Loader.label
+            loader_plugin.label
         ))
 
     # Get the new representation to switch to
@@ -1586,11 +1587,11 @@ def switch(container, representation):
     })
 
     new_context = get_representation_context(new_representation)
-    assert is_compatible_loader(Loader, new_context), ("Must be compatible "
-                                                       "Loader")
+    if not is_compatible_loader(loader_plugin, new_context):
+        raise AssertionError("Must be compatible Loader")
 
-    Loader = _make_backwards_compatible_loader(Loader)
-    loader = Loader(new_context)
+    loader_plugin = _make_backwards_compatible_loader(loader_plugin)
+    loader = loader_plugin(new_context)
 
     return loader.switch(container, new_representation)
 

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1472,15 +1472,25 @@ def load(Loader, representation, namespace=None, name=None, options=None,
     )
 
 
+def get_loader_identifier(loader):
+    """Loader identifier from loader plugin or object.
+
+    Identifier should be stored to container for future management.
+    """
+    if not inspect.isclass(loader):
+        loader = loader.__class__
+    return loader.__name__
+
+
 def _get_container_loader(container):
     """Return the Loader corresponding to the container"""
 
     loader = container["loader"]
     for Plugin in discover(Loader):
-
         # TODO: Ensure the loader is valid
-        if Plugin.__name__ == loader:
+        if get_loader_identifier(Plugin) == loader:
             return Plugin
+    return None
 
 
 def remove(container):

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -4,10 +4,8 @@ import os
 import sys
 import re
 import json
-import errno
 import types
 import copy
-import shutil
 import getpass
 import logging
 import weakref

--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -1268,3 +1268,21 @@ QSplitter {
 #IconView[mode="icon"]::icon {
     top: 3px;
 }
+
+#ButtonWithMenu {
+    padding-right: 12px;
+    border: 1px solid #4A4949;
+    border-radius: 2px;
+}
+#ButtonWithMenu::menu-button {
+    border: 1px solid #4A4949;
+    width: 12px;
+    border-top-left-radius: 0px;
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+    border-bottom-left-radius: 0px;
+}
+
+#ButtonWithMenu[state="1"], #ButtonWithMenu[state="1"]::menu-button, #ButtonWithMenu[state="1"]::menu-button:hover {
+    border-color: green;
+}

--- a/avalon/style/style.qss
+++ b/avalon/style/style.qss
@@ -1270,7 +1270,7 @@ QSplitter {
 }
 
 #ButtonWithMenu {
-    padding-right: 12px;
+    padding-right: 16px;
     border: 1px solid #4A4949;
     border-radius: 2px;
 }

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -1656,6 +1656,9 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             self._assets_box.setCurrentIndex(index)
 
     def _on_accept(self):
+        self._trigger_switch()
+
+    def _trigger_switch(self, loader=None):
         # Use None when not a valid value or when placeholder value
         selected_asset = self._assets_box.get_valid_value()
         selected_subset = self._subsets_box.get_valid_value()
@@ -1778,7 +1781,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                     repre_doc = repres_by_name[container_repre_name]
 
             try:
-                api.switch(container, repre_doc)
+                api.switch(container, repre_doc, loader)
             except Exception:
                 log.warning(
                     (

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -1185,7 +1185,19 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             if not loaders:
                 break
 
-        return list(loaders)
+        if loaders is None:
+            loaders = []
+        else:
+            loaders = list(loaders)
+
+        # Remove loader if there is only one which is same as context loader
+        if len(loaders) == 1 and len(self.content_loaders) == 1:
+            loader = loaders[0]
+            loader_name = pipeline.get_loader_identifier(loader)
+            if loader_name in self.content_loaders:
+                loaders.remove(loader)
+
+        return loaders
 
     def _fill_combobox(self, values, combobox_type):
         if combobox_type == "asset":

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -1507,6 +1507,19 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                 for repre_doc in repre_docs
             ]
 
+        # [ ] [ ] [x]
+        repre_docs = io.find(
+            {
+                "name": selected_repre,
+                "parent": {"$in": list(self.content_versions.keys())}
+            },
+            {"_id": True}
+        )
+        return [
+            repre_doc["_id"]
+            for repre_doc in repre_docs
+        ]
+
     def _get_asset_box_values(self):
         asset_docs = io.find(
             {"type": "asset"},

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -1291,7 +1291,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                     "name": selected_subset,
                     "parent": asset_doc["_id"]
                 },
-                {"_id": 1}
+                {"_id": True}
             )
             subset_id = subset_doc["_id"]
             last_versions_by_subset_id = self.find_last_versions([subset_id])
@@ -1302,14 +1302,12 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             repre_docs = io.find(
                 {
                     "type": "representation",
-                    "parent": version_doc["_id"]
+                    "parent": version_doc["_id"],
+                    "name": selected_repre
                 },
                 {"_id": True}
             )
-            return [
-                repre_doc["_id"]
-                for repre_doc in repre_docs
-            ]
+            return [repre_doc["_id"] for repre_doc in repre_docs]
 
         # [x] [x] [ ]
         # If asset and subset is selected
@@ -1320,7 +1318,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                     "parent": asset_doc["_id"],
                     "name": selected_subset
                 },
-                {"_id": 1}
+                {"_id": True}
             )
             if not subset_doc:
                 return []
@@ -1337,10 +1335,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                 },
                 {"_id": True}
             )
-            return [
-                repre_doc["_id"]
-                for repre_doc in repre_docs
-            ]
+            return [repre_doc["_id"] for repre_doc in repre_docs]
 
         # [x] [ ] [x]
         # If asset and repre is selected
@@ -1357,10 +1352,11 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                 {"_id": True}
             )
             subset_ids = [subset_doc["_id"] for subset_doc in subset_docs]
-            repre_docs = io.find(
+            repre_doc = io.find(
                 {
                     "type": "representation",
-                    "parent": {"$in": subset_ids}
+                    "parent": {"$in": subset_ids},
+                    "name": selected_repre
                 },
                 {"_id": True}
             )
@@ -1379,7 +1375,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
             asset_doc = io.find_one(
                 {"type": "asset", "name": selected_asset},
-                {"_id": 1}
+                {"_id": True}
             )
             subset_docs = list(io.find(
                 {
@@ -1416,10 +1412,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                 {"$or": repre_or_query},
                 {"_id": True}
             )
-            return [
-                repre_doc["_id"]
-                for repre_doc in repre_docs
-            ]
+            return [repre_doc["_id"] for repre_doc in repre_docs]
 
         # [ ] [x] [x]
         if selected_subset and selected_repre:
@@ -1440,10 +1433,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                 "name": selected_repre
             })
 
-            return [
-                repre_doc["_id"]
-                for repre_doc in repre_docs
-            ]
+            return [repre_doc["_id"] for repre_doc in repre_docs]
 
         # [ ] [x] [ ]
         if selected_subset:
@@ -1502,10 +1492,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                 {"_id": True}
             )
 
-            return [
-                repre_doc["_id"]
-                for repre_doc in repre_docs
-            ]
+            return [repre_doc["_id"] for repre_doc in repre_docs]
 
         # [ ] [ ] [x]
         repre_docs = io.find(
@@ -1515,10 +1502,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             },
             {"_id": True}
         )
-        return [
-            repre_doc["_id"]
-            for repre_doc in repre_docs
-        ]
+        return [repre_doc["_id"] for repre_doc in repre_docs]
 
     def _get_asset_box_values(self):
         asset_docs = io.find(

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -1352,7 +1352,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                 {"_id": True}
             )
             subset_ids = [subset_doc["_id"] for subset_doc in subset_docs]
-            repre_doc = io.find(
+            repre_docs = io.find(
                 {
                     "type": "representation",
                     "parent": {"$in": subset_ids},

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -1467,7 +1467,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             repre_names_by_asset_id = collections.defaultdict(set)
             for repre_doc in self.content_repres.values():
                 version_doc = self.content_versions[repre_doc["parent"]]
-                subset_doc = self.content_versions[version_doc["parent"]]
+                subset_doc = self.content_subsets[version_doc["parent"]]
                 asset_doc = self.content_assets[subset_doc["parent"]]
                 repre_name = repre_doc["name"]
                 asset_id = asset_doc["_id"]
@@ -1482,7 +1482,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                     continue
                 repre_or_query.append({
                     "parent": last_version_id,
-                    "name": {"$in": repre_names}
+                    "name": {"$in": list(repre_names)}
                 })
             repre_docs = io.find(
                 {

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -910,6 +910,23 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         self._init_subset_name = None
         self._init_repre_name = None
 
+        self.content_assets = {}
+        self.content_subsets = {}
+        self.content_versions = {}
+        self.content_repres = {}
+
+        self.hero_version_ids = set()
+
+        self.missing_assets = []
+        self.missing_versions = []
+        self.missing_subsets = []
+        self.missing_repres = []
+        self.missing_docs = False
+
+        self.archived_assets = []
+        self.archived_subsets = []
+        self.archived_repres = []
+
         self._accept_btn = accept_btn
         self._loaders_menu = loaders_menu
 

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -910,6 +910,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         self._init_subset_name = None
         self._init_repre_name = None
 
+        self.content_loaders = set()
         self.content_assets = {}
         self.content_subsets = {}
         self.content_versions = {}
@@ -941,13 +942,15 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         accept_btn.setFocus()
 
     def _prepare_content_data(self):
-        repre_ids = [
-            io.ObjectId(item["representation"])
-            for item in self._items
-        ]
+        repre_ids = set()
+        content_loaders = set()
+        for item in self._items:
+            repre_ids.add(io.ObjectId(item["representation"]))
+            content_loaders.add(item["loader"])
+
         repres = list(io.find({
             "type": {"$in": ["representation", "archived_representation"]},
-            "_id": {"$in": repre_ids}
+            "_id": {"$in": list(repre_ids)}
         }))
         repres_by_id = {repre["_id"]: repre for repre in repres}
 
@@ -1031,6 +1034,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             else:
                 content_assets[asset_id] = assets_by_id[asset_id]
 
+        self.content_loaders = content_loaders
         self.content_assets = content_assets
         self.content_subsets = content_subsets
         self.content_versions = content_versions

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -1155,6 +1155,251 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         self._accept_btn.setEnabled(validation_state.all_ok)
         self._accept_btn.setStyleSheet(accept_sheet or "")
 
+    def _get_current_output_repre_ids(self):
+        # NOTE hero versions are not used because it is expected that
+        # hero version has same representations as latests
+        selected_asset = self._assets_box.currentText()
+        selected_subset = self._subsets_box.currentText()
+        selected_repre = self._representations_box.currentText()
+
+        # Nothing is selected
+        # [ ] [ ] [ ]
+        if not selected_asset and not selected_subset and not selected_repre:
+            return list(self.content_repres.keys())
+
+        # Prepare asset document if asset is selcted
+        if selected_asset:
+            asset_doc = io.find_one(
+                {"type": "asset", "name": selected_asset},
+                {"_id": True}
+            )
+            if not asset_doc:
+                return []
+
+        # Everything is selected
+        # [x] [x] [x]
+        if selected_asset and selected_subset and selected_repre:
+            subset_doc = io.find_one(
+                {
+                    "type": "subset",
+                    "name": selected_subset,
+                    "parent": asset_doc["_id"]
+                },
+                {"_id": 1}
+            )
+            subset_id = subset_doc["_id"]
+            last_versions_by_subset_id = self.find_last_versions([subset_id])
+            version_doc = last_versions_by_subset_id.get(subset_id)
+            if not version_doc:
+                return []
+
+            repre_docs = io.find(
+                {
+                    "type": "representation",
+                    "parent": version_doc["_id"]
+                },
+                {"_id": True}
+            )
+            return [
+                repre_doc["_id"]
+                for repre_doc in repre_docs
+            ]
+
+        # [x] [x] [ ]
+        # If asset and subset is selected
+        if selected_asset and selected_subset:
+            subset_doc = io.find_one(
+                {
+                    "type": "subset",
+                    "parent": asset_doc["_id"],
+                    "name": selected_subset
+                },
+                {"_id": 1}
+            )
+            if not subset_doc:
+                return []
+
+            repre_names = set()
+            for repre_doc in self.content_repres.values():
+                repre_names.add(repre_doc["name"])
+
+            repre_docs = io.find(
+                {
+                    "type": "rerpesentation",
+                    "parent": subset_doc["_id"],
+                    "name": {"$in": list(repre_names)}
+                },
+                {"_id": True}
+            )
+            return [
+                repre_doc["_id"]
+                for repre_doc in repre_docs
+            ]
+
+        # [x] [ ] [x]
+        # If asset and repre is selected
+        if selected_asset and selected_repre:
+            susbet_names = set()
+            for subset_doc in self.content_subsets.values():
+                susbet_names.add(subset_doc["name"])
+
+            subset_docs = io.find(
+                {
+                    "type": "subset",
+                    "name": {"$in": list(susbet_names)}
+                },
+                {"_id": True}
+            )
+            subset_ids = [subset_doc["_id"] for subset_doc in subset_docs]
+            repre_docs = io.find(
+                {
+                    "type": "representation",
+                    "parent": {"$in": subset_ids}
+                },
+                {"_id": True}
+            )
+            return [repre_doc["_id"] for repre_doc in repre_docs]
+
+        # [x] [ ] [ ]
+        # If asset and subset is selected
+        if selected_asset:
+            repres_by_subset_name = collections.defaultdict(set)
+            for repre_doc in self.content_repres.values():
+                repre_name = repre_doc["name"]
+                version_doc = self.content_versions[repre_doc["parent"]]
+                subset_doc = self.content_subsets[version_doc["parent"]]
+                subset_name = subset_doc["name"]
+                repres_by_subset_name[subset_name].add(repre_name)
+
+            asset_doc = io.find_one(
+                {"type": "asset", "name": selected_asset},
+                {"_id": 1}
+            )
+            subset_docs = list(io.find(
+                {
+                    "type": "subset",
+                    "parent": asset_doc["_id"],
+                    "name": {"$in": list(repres_by_subset_name.keys())}
+                },
+                {"_id": True, "name": True}
+            ))
+            subset_name_by_id = {
+                subset_doc["_id"]: subset_doc["name"]
+                for subset_doc in subset_docs
+            }
+            subset_ids = list(subset_name_by_id.keys())
+            last_versions_by_subset_id = self.find_last_versions(subset_ids)
+            last_version_id_by_subset_name = {}
+            for subset_id, last_version in last_versions_by_subset_id.items():
+                subset_name = subset_name_by_id[subset_id]
+                last_version_id_by_subset_name[subset_name] = (
+                    last_version["_id"]
+                )
+
+            repre_or_query = []
+            for subset_name, repre_names in repres_by_subset_name.items():
+                version_id = last_version_id_by_subset_name.get(subset_name)
+                # This should not happen but why to crash?
+                if version_id is None:
+                    continue
+                repre_or_query.append({
+                    "parent": version_id,
+                    "name": {"$in": list(repre_names)}
+                })
+            repre_docs = io.find(
+                {"$or": repre_or_query},
+                {"_id": True}
+            )
+            return [
+                repre_doc["_id"]
+                for repre_doc in repre_docs
+            ]
+
+        # [ ] [x] [x]
+        if selected_subset and selected_repre:
+            subset_docs = list(io.find({
+                "type": "subset",
+                "parent": {"$in": list(self.content_assets.keys())},
+                "name": selected_subset
+            }))
+            subset_ids = [subset_doc["_id"] for subset_doc in subset_docs]
+            last_versions_by_subset_id = self.find_last_versions(subset_ids)
+            last_version_ids = [
+                last_version["_id"]
+                for last_version in last_versions_by_subset_id.values()
+            ]
+            repre_docs = io.find({
+                "type": "representation",
+                "parent": {"$in": last_version_ids},
+                "name": selected_repre
+            })
+
+            return [
+                repre_doc["_id"]
+                for repre_doc in repre_docs
+            ]
+
+        # [ ] [x] [ ]
+        subset_docs = list(io.find(
+            {
+                "type": "subset",
+                "parent": {"$in": list(self.content_assets.keys())},
+                "name": selected_subset
+            },
+            {"_id": 1, "parent": 1}
+        ))
+        if not subset_docs:
+            return list()
+
+        subset_docs_by_id = {
+            subset_doc["_id"]: subset_doc
+            for subset_doc in subset_docs
+        }
+        last_versions_by_subset_id = self.find_last_versions(
+            subset_docs_by_id.keys()
+        )
+
+        subset_id_by_version_id = {}
+        for subset_id, last_version in last_versions_by_subset_id.items():
+            version_id = last_version["_id"]
+            subset_id_by_version_id[version_id] = subset_id
+
+        if not subset_id_by_version_id:
+            return list()
+
+        repre_names_by_asset_id = collections.defaultdict(set)
+        for repre_doc in self.content_repres.values():
+            version_doc = self.content_versions[repre_doc["parent"]]
+            subset_doc = self.content_versions[version_doc["parent"]]
+            asset_doc = self.content_assets[subset_doc["parent"]]
+            repre_name = repre_doc["name"]
+            asset_id = asset_doc["_id"]
+            repre_names_by_asset_id[asset_id].add(repre_name)
+
+        repre_or_query = []
+        for last_version_id, subset_id in subset_id_by_version_id.items():
+            subset_doc = subset_docs_by_id[subset_id]
+            asset_id = subset_doc["parent"]
+            repre_names = repre_names_by_asset_id.get(asset_id)
+            if not repre_names:
+                continue
+            repre_or_query.append({
+                "parent": last_version_id,
+                "name": {"$in": repre_names}
+            })
+        repre_docs = io.find(
+            {
+                "type": "representation",
+                "$or": repre_or_query
+            },
+            {"_id": 1}
+        )
+
+        return [
+            repre_doc["_id"]
+            for repre_doc in repre_docs
+        ]
+
     def _get_asset_box_values(self):
         asset_docs = io.find(
             {"type": "asset"},

--- a/avalon/tools/sceneinventory/app.py
+++ b/avalon/tools/sceneinventory/app.py
@@ -879,6 +879,8 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         accept_btn.setFixedWidth(24)
         accept_btn.setFixedHeight(24)
 
+        loaders_menu = QtWidgets.QMenu(accept_btn)
+
         # Asset column
         main_layout.addWidget(self.current_asset_btn, 0, 0)
         main_layout.addWidget(self._assets_box, 1, 0)
@@ -892,8 +894,6 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         # Btn column
         main_layout.addWidget(accept_btn, 1, 3)
 
-        self._accept_btn = accept_btn
-
         self._assets_box.currentIndexChanged.connect(
             self._combobox_value_changed
         )
@@ -903,12 +903,15 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         self._representations_box.currentIndexChanged.connect(
             self._combobox_value_changed
         )
-        self._accept_btn.clicked.connect(self._on_accept)
+        accept_btn.clicked.connect(self._on_accept)
         self.current_asset_btn.clicked.connect(self._on_current_asset)
 
         self._init_asset_name = None
         self._init_subset_name = None
         self._init_repre_name = None
+
+        self._accept_btn = accept_btn
+        self._loaders_menu = loaders_menu
 
         self._items = items
         self._prepare_content_data()


### PR DESCRIPTION
## Description
Add option to choose from different loaders in switch dialog.

## Changes
- added function `get_loader_identifier` to extract loader identifier (name)
- switch function may expect loader which will be used for switching
- switch dialog changes
    - new method to get representation ids for currently context (selected containers and combobox values)
    - have option to show menu popup if there are multiple loaders that can be used for loading
        - loaders must match for all representations retrieved from currentl context of dialog
        - loaders must have `switch` method available
        - loaders with attribute `is_utility` set to True are skipped
   - first option of menu is to `Use origin loaders` which will use loaders from containers
   - the menu is not available if there is only one available loader which is same as for all containers

### Notes
- label `Use origin loaders` probably won't make sense for artists (feel free to modify)
- should be menu showed all the time and show only the loader same for all containers?
- stylesheet for arrow in pushbutton is not the best (arrow is over the icon) not sure how to fix and not break other tools
    - suggestion: move sceneinvetory to openpype tools and refactor the ui creation which would help to handle that easier