### PR TITLE
General: Skip "api" module name on finding host implementation

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -99,7 +99,11 @@ def install(host):
         host.install()
 
     # Optional config.host.install()
-    host_name = host.__name__.rsplit(".", 1)[-1]
+    host_name_parts = host.__name__.split(".")
+    host_name = host_name_parts[-1]
+    # Go to second from end if last item name is named 'api'
+    if host_name == "api":
+        host_name = host_name_parts[-2]
     config_host = lib.find_submodule(config, host_name)
     if config_host != host:
         if hasattr(config_host, "install"):


### PR DESCRIPTION
## Issue
- when is installed host implementation which is available only in openpype it is installing module named `openpype.hosts.<host name>.api` instad of `openpype.hosts.<host name>` which cause a lot of warnings in `find_submodule` function which may be terrifting.

## Changes
- skip "api" host name and use splitted part before that