### PR TITLE
Add parent in template_data_from_session 

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -1181,7 +1181,8 @@ def template_data_from_session(session):
         # Optional
         "silo": session.get("AVALON_SILO"),
         "user": session.get("AVALON_USER", getpass.getuser()),
-        "hierarchy": hierarchy
+        "hierarchy": hierarchy,
+        "parent": asset_parents[-1] or project_name,
     }
 
 


### PR DESCRIPTION
I added the parent key in template_data_from_session to solve the problem when changing tasks in the work file interface.
Link to [OpenPypeV3: Add key parent asset to path templating construction](https://github.com/pypeclub/OpenPype/pull/2186)