### PR TITLE
Fix Adobe extension closing issue

### DIFF
--- a/avalon/aftereffects/launch_logic.py
+++ b/avalon/aftereffects/launch_logic.py
@@ -155,8 +155,8 @@ class ProcessLauncher(QtCore.QObject):
             self.log.info("Host process is not running. Closing")
             self.exit()
 
-        elif not self.is_host_connected:
-            self.log.info("Host is not connected. Closing")
+        elif not self.websocket_server_is_running:
+            self.log.info("Websocket server is not running. Closing")
             self.exit()
 
     def _on_start_process_timer(self):

--- a/avalon/photoshop/launch_logic.py
+++ b/avalon/photoshop/launch_logic.py
@@ -155,8 +155,8 @@ class ProcessLauncher(QtCore.QObject):
             self.log.info("Host process is not running. Closing")
             self.exit()
 
-        elif not self.is_host_connected:
-            self.log.info("Host is not connected. Closing")
+        elif not self.websocket_server_is_running:
+            self.log.info("Websocket server is not running. Closing")
             self.exit()
 
     def _on_start_process_timer(self):


### PR DESCRIPTION
If user uses extension in non docked version, closing of extension menu caused closing of host app.

How to test it:
---------------
- before fix detach extension menu to floating window, close this extension window
- do the same after fix is applied