### PR TITLE
Unreal: Dynamic menu created in Python

### DIFF
--- a/avalon/unreal/__init__.py
+++ b/avalon/unreal/__init__.py
@@ -18,6 +18,8 @@ from .pipeline import (
     show_manager,
     show_project_manager,
     show_experimental_tools,
+    show_tools_dialog,
+    show_tools_popup,
     instantiate,
 )
 
@@ -37,6 +39,8 @@ __all__ = [
     "show_manager",
     "show_project_manager",
     "show_experimental_tools",
+    "show_tools_dialog",
+    "show_tools_popup",
     "maintained_selection",
     "instantiate",
 ]

--- a/avalon/unreal/pipeline.py
+++ b/avalon/unreal/pipeline.py
@@ -215,6 +215,26 @@ def imprint(node, data):
         unreal.EditorAssetLibrary.save_asset(node)
 
 
+def show_tools_popup():
+    """Show popup with tools.
+
+    Popup will disappear on click or loosing focus.
+    """
+    from openpype.hosts.unreal.api import tools_ui
+
+    tools_ui.show_tools_popup()
+
+
+def show_tools_dialog():
+    """Show dialog with tools.
+
+    Dialog will stay visible.
+    """
+    from openpype.hosts.unreal.api import tools_ui
+
+    tools_ui.show_tools_dialog()
+
+
 def show_creator():
     host_tools.show_creator()
 


### PR DESCRIPTION
## Brief description
Menu items are not defined by unreal plugin which may be complicated as plugin is compiled on project reation and then is not updated.

## Description
It is better to create menu dynamically in python and menu in Unreal will have only 2 action callbacks.
- one will show tools in a dialog which will stay until user close it
- second will show tools in popup which will close on loose of focus

## Changes
- added `show_tools_dialog` and `show_tools_popup` using `tools_ui` from openpype's unreal

||Depends on|
|---|---|
|openpype|https://github.com/pypeclub/OpenPype/pull/2422|
|unreal-plugin|https://github.com/pypeclub/avalon-unreal-integration/pull/3|