### PR TITLE
Harmony: Experimental tools callback

### DIFF
--- a/avalon/harmony/TB_sceneOpened.js
+++ b/avalon/harmony/TB_sceneOpened.js
@@ -462,6 +462,22 @@ function start() {
         action.triggered.connect(self.onSubsetManage);
     }
 
+    /**
+      * Show Experimental dialog
+      */
+    self.onExperimentalTools = function() {
+        app.avalonClient.send({
+            'module': 'avalon.harmony.lib',
+            'method': 'show',
+            'args': ['experimental_tools']
+        }, false);
+    };
+    // add Subset Manager item to menu
+    if (app.avalonMenu == null) {
+        action = menu.addAction('Experimental Tools...');
+        action.triggered.connect(self.onExperimentalTools);
+    }
+
     // FIXME(antirotor): We need to disable `on_file_changed` now as is wreak
     // havoc when "Save" is called multiple times and zipping didn't finished yet
     /*

--- a/avalon/harmony/TB_sceneOpened.js
+++ b/avalon/harmony/TB_sceneOpened.js
@@ -449,7 +449,7 @@ function start() {
     /**
       * Show Subset Manager
       */
-    self.onManage = function() {
+    self.onSubsetManage = function() {
         app.avalonClient.send({
             'module': 'avalon.harmony.lib',
             'method': 'show',
@@ -459,7 +459,7 @@ function start() {
     // add Subset Manager item to menu
     if (app.avalonMenu == null) {
         action = menu.addAction('Subset Manager...');
-        action.triggered.connect(self.onManage);
+        action.triggered.connect(self.onSubsetManage);
     }
 
     // FIXME(antirotor): We need to disable `on_file_changed` now as is wreak


### PR DESCRIPTION
## Description
Add experimental tools callback.

## Changes
- added experimental tools button in harmony
- fixed duplicated `onManage` function