### PR TITLE
Ensure unique name during renaming to avoid errors on naming conflicts

### DIFF
--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -145,7 +145,7 @@ def containerise(name,
     # Create proper container name
     container_name = "{}_{}".format(name, suffix or "CON")
     container = hou.node("/obj/{}".format(name))
-    container.setName(container_name)
+    container.setName(container_name, unique_name=True)
 
     data = {
         "schema": "openpype:container-2.0",


### PR DESCRIPTION
Simple fix to avoid naming conflicts during `avalon.houdini.pipeline.containerise`.