### PR TITLE
Add build workfile to photoshop menu

### DIFF
--- a/avalon/photoshop/extension/index.html
+++ b/avalon/photoshop/extension/index.html
@@ -12,7 +12,7 @@
       }
       button {width: 100%;}
     </style>
-    
+
     <style>
       button {width: 100%;}
       body {margin:0; padding:0; height: 100%;}
@@ -20,7 +20,7 @@
     </style>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js">
     </script>
-    
+
     <script type=text/javascript>
             $(function() {
               $("a#workfiles-button").bind("click", function() {
@@ -31,7 +31,7 @@
               });
             });
     </script>
-    
+
     <script type=text/javascript>
             $(function() {
               $("a#creator-button").bind("click", function() {
@@ -42,7 +42,7 @@
               });
             });
     </script>
-    
+
     <script type=text/javascript>
             $(function() {
               $("a#loader-button").bind("click", function() {
@@ -53,7 +53,7 @@
               });
             });
     </script>
-    
+
     <script type=text/javascript>
             $(function() {
               $("a#publish-button").bind("click", function() {
@@ -64,7 +64,18 @@
               });
             });
     </script>
-    
+
+    <script type=text/javascript>
+      $(function() {
+        $("a#build-button").bind("click", function() {
+          RPC.call('Photoshop.buildworkfile_route').then(function (data) {
+          }, function (error) {
+              alert(error);
+          });
+        });
+      });
+    </script>
+
     <script type=text/javascript>
             $(function() {
               $("a#sceneinventory-button").bind("click", function() {
@@ -91,16 +102,17 @@
   <script type="text/javascript" src="./client/wsrpc.js"></script>
   <script type="text/javascript" src="./client/CSInterface.js"></script>
   <script type="text/javascript" src="./client/loglevel.min.js"></script>
-  
+
   <!-- helper library for better debugging of .jsx check its license! -->
   <script type="text/javascript" src="./host/JSX.js"></script>
-  
+
   <script type="text/javascript" src="./client/client.js"></script>
-  
+
     <a href=# id=workfiles-button><button>Workfiles...</button></a>
     <a href=# id=creator-button><button>Create...</button></a>
     <a href=# id=loader-button><button>Load...</button></a>
     <a href=# id=publish-button><button>Publish...</button></a>
+    <a href=# id=build-button><button>Build Workfile...</button></a>
     <a href=# id=sceneinventory-button><button>Manage...</button></a>
     <a href=# id=subsetmanager-button><button>Subset Manager...</button></a>
 </body>

--- a/avalon/photoshop/lib.py
+++ b/avalon/photoshop/lib.py
@@ -124,6 +124,9 @@ class PhotoshopRoute(WebSocketRoute):
     async def publish_route(self):
         self._tool_route("publish")
 
+    async def buildworkfile_route(self):
+        self._tool_route("buildworkfile")
+
     async def sceneinventory_route(self):
         self._tool_route("sceneinventory")
 

--- a/avalon/tools/buildworkfile/__init__.py
+++ b/avalon/tools/buildworkfile/__init__.py
@@ -1,0 +1,7 @@
+from .app import (
+    show
+)
+
+__all__ = [
+    "show",
+]

--- a/avalon/tools/buildworkfile/app.py
+++ b/avalon/tools/buildworkfile/app.py
@@ -1,0 +1,6 @@
+from openpype.lib.build_template import build_workfile_template
+
+
+def show(root=None, debug=False, parent=None, use_context=True, save=True):
+    """Proxy function used to trick photoshop menu to build a scene"""
+    build_workfile_template()


### PR DESCRIPTION
**What's changed?**
Adding an option for Photoshop OpenPype menu to use currently developped "Templated Build Workfile".
Waiting for https://github.com/pypeclub/OpenPype/pull/2202 and https://github.com/pypeclub/OpenPype/pull/2466 

**Examples**
If you are unsure of how to format your pull-request, have a look at these examples. [#403](https://github.com/getavalon/core/pull/403), [#400](https://github.com/getavalon/core/pull/400)
