### PR TITLE
Fix ls() for Hou 19 with Py3

### DIFF
--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -199,7 +199,11 @@ def ls():
     if hasattr(config_host, "collect_container_metadata"):
         has_metadata_collector = True
 
-    for container in sorted(containers):
+    for container in sorted(containers,
+                            # Hou 19+ Python 3 hou.ObjNode are not
+                            # sortable due to not supporting greater
+                            # than comparisons
+                            key=lambda node: node.path()):
         data = parse_container(container)
 
         # Collect custom data if attribute is present


### PR DESCRIPTION
**What's changed?**

Houdini 19+ Python 3 `hou.Node` instances can't be compared with Python's `<` and thus `sorted()` fails by default.

To reproduce the error, before this PR:

1. open e.g. Houdini 19.0.455 with Python 3.
2. load a few models with the pipeline.
3. Run the following code:
```python
import avalon.api
host = avalon.api.registered_host()
list(host.ls())
```

The following error is generated:
```python
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "S:\openpype\OpenPype\repos\avalon-core\avalon\houdini\pipeline.py", line 202
, in ls
    for container in sorted(containers):
TypeError: '<' not supported between instances of 'ObjNode' and 'ObjNode'
```

This PR resolves that issue and also works fine in older Houdini releases.

Without this PR loaded assets will not be shown in the Scene Inventory (OpenPype > Manage..) due to this same error being triggered.