### PR TITLE
lsattrs: Fix Py3 compatibility for Maya 2022

### DIFF
--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -477,7 +477,7 @@ def lsattrs(attrs):
     dag_fn = om.MFnDagNode()
     selection_list = om.MSelectionList()
 
-    first_attr = attrs.iterkeys().next()
+    first_attr = next(iter(attrs))
 
     try:
         selection_list.add("*.{0}".format(first_attr),


### PR DESCRIPTION
**What's changed?**

Minor fix for Python 3 compatibility of `lsattrs` function since `.iterkeys()` does not exist in Py3.