### PR TITLE
Maya: unique_namespace fails while in an namespace that is empty

### DIFF
--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -69,7 +69,7 @@ def unique_namespace(namespace, format="%02d", prefix="", suffix=""):
     # within "current namespace". We need all because the namespace could
     # also clash with a node name. To be truly unique and valid one needs to
     # check against all.
-    existing = set(cmds.namespaceInfo(listNamespace=True))
+    existing = set(cmds.namespaceInfo(listNamespace=True) or [])
     while unique in existing:
         iteration += 1
         unique = prefix + (namespace + format % iteration) + suffix

--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -60,21 +60,51 @@ def unique_namespace(namespace, format="%02d", prefix="", suffix=""):
         format (str, optional): Formatting of the given iteration number
         suffix (str, optional): Only consider namespaces with this suffix.
 
+    >>> unique_namespace("bar")
+    # bar01
+    >>> unique_namespace(":hello")
+    # :hello01
+    >>> unique_namespace("bar:", suffix="_NS")
+    # bar01_NS:
+
     """
 
+    def current_namespace():
+        current = cmds.namespaceInfo(currentNamespace=True,
+                                     absoluteName=True)
+        # When inside a namespace Maya adds no trailing :
+        if not current.endswith(":"):
+            current += ":"
+        return current
+
+    # Always check against the absolute namespace root
+    # There's no clash with :x if we're defining namespace :a:x
+    ROOT = ":" if namespace.startswith(":") else current_namespace()
+
+    # Strip trailing `:` tokens since we might want to add a suffix
+    start = ":" if namespace.startswith(":") else ""
+    end = ":" if namespace.endswith(":") else ""
+    namespace = namespace.strip(":")
+    if ":" in namespace:
+        # Split off any nesting that we don't uniqify anyway.
+        parents, namespace = namespace.rsplit(":", 1)
+        start += parents + ":"
+        ROOT += start
+
+    def exists(n):
+        # Check for clash with nodes and namespaces
+        fullpath = ROOT + n
+        return cmds.objExists(fullpath) or cmds.namespace(exists=fullpath)
+
     iteration = 1
-    unique = prefix + (namespace + format % iteration) + suffix
+    while True:
+        nr_namespace = namespace + format % iteration
+        unique = prefix + nr_namespace + suffix
 
-    # The `existing` set does not just contain the namespaces but *all* nodes
-    # within "current namespace". We need all because the namespace could
-    # also clash with a node name. To be truly unique and valid one needs to
-    # check against all.
-    existing = set(cmds.namespaceInfo(listNamespace=True) or [])
-    while unique in existing:
+        if not exists(unique):
+            return start + unique + end
+
         iteration += 1
-        unique = prefix + (namespace + format % iteration) + suffix
-
-    return unique
 
 
 def read(node):


### PR DESCRIPTION
**What's changed?**

While I was testing some things with namespaces I noticed this method errors out when requesting a unique namespace when your current active namespace is not the root namespace `:` and the namespace you are in has no children. It's because when no children are in the current namespace at all then `cmds.namespaceInfo(listNamespace=True)` returns `None` instead of an empty list.

***Reproducable***
```python
from maya import cmds

# In the root namespace there are always some hidden built-in namespaces
# so in most scenarios it never returns nothing
cmds.namespace(set=":")
print(cmds.namespaceInfo(listNamespace=True))
# ['CubeCompass', 'CustomGPUCacheFilter', 'DefaultAllLightsFilter', ... and many more ]

# However, when current namespace is IN a namespace. That's different.
cmds.namespace(add="hello")
cmds.namespace(set="hello")
print(cmds.namespaceInfo(listNamespace=True))
# None
```

And reproducing the actual error:
```python
from maya import cmds
import avalon.maya.lib

cmds.namespace(add="foo")
cmds.namespace(set="foo")
avalon.maya.lib.unique_namespace("namespace")

# Error: 'NoneType' object is not iterable
# Traceback (most recent call last):
#   File "<maya console>", line 6, in <module>
#   File "avalon-core\avalon\maya\lib.py", line 72, in unique_namespace
#     existing = set(cmds.namespaceInfo(listNamespace=True) or [])
# TypeError: 'NoneType' object is not iterable # 
```

---

This also fixes a case in OpenPype where loading assets whilst within a namespace can fail due to this function being called.

_Tested in Maya 2020.4 and Maya 2022.1_ 👍 
