### PR TITLE
Hou: fix ls() Avoid hou.PermissionError when iterating some types of locked nodes

### DIFF
--- a/avalon/houdini/lib.py
+++ b/avalon/houdini/lib.py
@@ -61,18 +61,37 @@ def imprint(node, data):
     node.setParmTemplateGroup(parm_group)
 
 
-def lsattr(attr, value=None):
+def lsattr(attr, value=None, root="/"):
+    """Return nodes that have `attr`
+
+     When `value` is not None it will only return nodes matching that value
+     for the given attribute.
+
+     Args:
+         attr (str): Name of the attribute (hou.Parm)
+         value (object, Optional): The value to compare the attribute too.
+            When the default None is provided the value check is skipped.
+        root (str): The root path in Houdini to search in.
+
+    Returns:
+        list: Matching nodes that have attribute with value.
+
+    """
     if value is None:
-        nodes = list(hou.node("/obj").allNodes())
+        # Use allSubChildren() as allNodes() errors on nodes without
+        # permission to enter without a means to continue of querying
+        # the rest
+        nodes = hou.node(root).allSubChildren()
         return [n for n in nodes if n.parm(attr)]
     return lsattrs({attr: value})
 
 
-def lsattrs(attrs):
+def lsattrs(attrs, root="/"):
     """Return nodes matching `key` and `value`
 
     Arguments:
         attrs (dict): collection of attribute: value
+        root (str): The root path in Houdini to search in.
 
     Example:
         >> lsattrs({"id": "myId"})
@@ -81,11 +100,14 @@ def lsattrs(attrs):
         ["myNode", "myOtherNode"]
 
     Returns:
-        list
+        list: Matching nodes that have attribute with value.
     """
 
     matches = set()
-    nodes = list(hou.node("/obj").allNodes())  # returns generator object
+    # Use allSubChildren() as allNodes() errors on nodes without
+    # permission to enter without a means to continue of querying
+    # the rest
+    nodes = hou.node(root).allSubChildren()
     for node in nodes:
         for attr in attrs:
             if not node.parm(attr):


### PR DESCRIPTION
Fixes some cases where `ls()` would fail due to PermissionErrors where Houdini isn't allowed to iterate into specific locked nodes/HDAs as [reported by Desmond on Discord](https://discord.com/channels/517362899170230292/517382145552154634/935474296501993513).

I [had this fixed before](https://github.com/Colorbleed/core/commit/7ec5e977243615657a5124493ba82c94624c34ef) so I've taken the latest code I had in place for that.

Note that this also includes code changes related to [this commit](https://github.com/Colorbleed/core/commit/450737514d6b9707de0c7dc07f68242c41c8c0fb) that I had done outside of OpenPype before. That does mean that it technically iterates more nodes (also those outside of `/obj`) but it shouldn't pose an issue.